### PR TITLE
Put all methods on UserDefaults and remove Defaults

### DIFF
--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -1,27 +1,30 @@
 // MIT License © Sindre Sorhus
 import Foundation
 
-public class DefaultsKeys {
-	fileprivate init() {}
-}
+public extension UserDefaults {
+	public class Keys {
+		fileprivate init() {}
+	}
 
-public final class DefaultsKey<T: Codable>: DefaultsKeys {
-	fileprivate let name: String
-	fileprivate let defaultValue: T
+	public final class Key<T: Codable>: Keys {
+		fileprivate let name: String
+		fileprivate let defaultValue: T
 
-	public init(_ key: String, default defaultValue: T) {
-		self.name = key
-		self.defaultValue = defaultValue
+		public init(_ key: String, default defaultValue: T) {
+			self.name = key
+			self.defaultValue = defaultValue
+		}
+	}
+
+	public final class OptionalKey<T: Codable>: Keys {
+		fileprivate let name: String
+
+		public init(_ key: String) {
+			self.name = key
+		}
 	}
 }
 
-public final class DefaultsOptionalKey<T: Codable>: DefaultsKeys {
-	fileprivate let name: String
-
-	public init(_ key: String) {
-		self.name = key
-	}
-}
 
 // Has to be `defaults` lowercase until Swift supports static subscripts…
 public let Defaults = UserDefaults.standard
@@ -64,7 +67,7 @@ public extension UserDefaults {
 		}
 	}
 
-	public subscript<T: Codable>(key: DefaultsKey<T>) -> T {
+	public subscript<T: Codable>(key: Key<T>) -> T {
 		get {
 			return _get(key.name) ?? key.defaultValue
 		}
@@ -73,7 +76,7 @@ public extension UserDefaults {
 		}
 	}
 
-	public subscript<T: Codable>(key: DefaultsOptionalKey<T>) -> T? {
+	public subscript<T: Codable>(key: OptionalKey<T>) -> T? {
 		get {
 			return _get(key.name)
 		}

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -1,54 +1,30 @@
 // MIT License © Sindre Sorhus
 import Cocoa
 
-public final class Defaults {
-	public class Keys {}
+public class DefaultsKeys {
+	fileprivate init() {}
+}
 
-	public final class Key<T: Codable>: Keys {
-		fileprivate let name: String
-		fileprivate let defaultValue: T
+public final class DefaultsKey<T: Codable>: DefaultsKeys {
+	fileprivate let name: String
+	fileprivate let defaultValue: T
 
-		init(_ key: String, default defaultValue: T) {
-			self.name = key
-			self.defaultValue = defaultValue
-		}
+	public init(_ key: String, default defaultValue: T) {
+		self.name = key
+		self.defaultValue = defaultValue
 	}
+}
 
-	public final class OptionalKey<T: Codable>: Keys {
-		fileprivate let name: String
+public final class DefaultsOptionalKey<T: Codable>: DefaultsKeys {
+	fileprivate let name: String
 
-		init(_ key: String) {
-			self.name = key
-		}
-	}
-
-	public subscript<T: Codable>(key: Defaults.Key<T>) -> T {
-		get {
-			return UserDefaults.standard[key]
-		}
-		set {
-			UserDefaults.standard[key] = newValue
-		}
-	}
-
-	public subscript<T: Codable>(key: Defaults.OptionalKey<T>) -> T? {
-		get {
-			return UserDefaults.standard[key]
-		}
-		set {
-			UserDefaults.standard[key] = newValue
-		}
-	}
-
-	public func clear() {
-		for key in UserDefaults.standard.dictionaryRepresentation().keys {
-			UserDefaults.standard.removeObject(forKey: key)
-		}
+	public init(_ key: String) {
+		self.name = key
 	}
 }
 
 // Has to be `defaults` lowercase until Swift supports static subscripts…
-public let defaults = Defaults()
+public let Defaults = UserDefaults.standard
 
 public extension UserDefaults {
 	private func _get<T: Codable>(_ key: String) -> T? {
@@ -88,7 +64,7 @@ public extension UserDefaults {
 		}
 	}
 
-	public subscript<T: Codable>(key: Defaults.Key<T>) -> T {
+	public subscript<T: Codable>(key: DefaultsKey<T>) -> T {
 		get {
 			return _get(key.name) ?? key.defaultValue
 		}
@@ -97,7 +73,7 @@ public extension UserDefaults {
 		}
 	}
 
-	public subscript<T: Codable>(key: Defaults.OptionalKey<T>) -> T? {
+	public subscript<T: Codable>(key: DefaultsOptionalKey<T>) -> T? {
 		get {
 			return _get(key.name)
 		}
@@ -119,6 +95,12 @@ public extension UserDefaults {
 			return true
 		default:
 			return false
+		}
+	}
+
+	public func clear() {
+		for key in dictionaryRepresentation().keys {
+			removeObject(forKey: key)
 		}
 	}
 }

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -1,5 +1,5 @@
 // MIT License © Sindre Sorhus
-import Cocoa
+import Foundation
 
 public class DefaultsKeys {
 	fileprivate init() {}

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Defaults
+import Defaults
 
 let fixtureUrl = URL(string: "httos://sindresorhus.com")!
 
@@ -9,54 +9,54 @@ enum FixtureEnum: String, Codable {
 	case oneHour = "1 Hour"
 }
 
-extension Defaults.Keys {
-	static let key = Defaults.Key<Bool>("key", default: false)
-	static let url = Defaults.Key<URL>("url", default: fixtureUrl)
-	static let `enum` = Defaults.Key<FixtureEnum>("enum", default: .oneHour)
+extension DefaultsKeys {
+	static let key = DefaultsKey<Bool>("key", default: false)
+	static let url = DefaultsKey<URL>("url", default: fixtureUrl)
+	static let `enum` = DefaultsKey<FixtureEnum>("enum", default: .oneHour)
 }
 
 final class DefaultsTests: XCTestCase {
 	override func setUp() {
 		super.setUp()
-		defaults.clear()
+		Defaults.clear()
 	}
 
-    func testKey() {
-		let key = Defaults.Key<Bool>("key", default: false)
+	func testKey() {
+		let key = DefaultsKey<Bool>("key", default: false)
 		XCTAssertFalse(UserDefaults.standard[key])
 		UserDefaults.standard[key] = true
 		XCTAssertTrue(UserDefaults.standard[key])
 	}
 
 	func testOptionalKey() {
-		let key = Defaults.OptionalKey<Bool>("key")
+		let key = DefaultsOptionalKey<Bool>("key")
 		XCTAssertNil(UserDefaults.standard[key])
 		UserDefaults.standard[key] = true
 		XCTAssertTrue(UserDefaults.standard[key]!)
 	}
 
 	func testKeys() {
-		XCTAssertFalse(defaults[.key])
-		defaults[.key] = true
-		XCTAssertTrue(defaults[.key])
+		XCTAssertFalse(Defaults[.key])
+		Defaults[.key] = true
+		XCTAssertTrue(Defaults[.key])
 	}
 
 	func testUrlType() {
-		XCTAssertEqual(defaults[.url], fixtureUrl)
+		XCTAssertEqual(Defaults[.url], fixtureUrl)
 
 		let newUrl = URL(string: "https://twitter.com")!
-		defaults[.url] = newUrl
-		XCTAssertEqual(defaults[.url], newUrl)
+		Defaults[.url] = newUrl
+		XCTAssertEqual(Defaults[.url], newUrl)
 	}
 
 	func testEnumType() {
-		XCTAssertEqual(defaults[.enum], FixtureEnum.oneHour)
+		XCTAssertEqual(Defaults[.enum], FixtureEnum.oneHour)
 	}
 
 	func testClear() {
-		defaults[.key] = true
-		XCTAssertTrue(defaults[.key])
-		defaults.clear()
-		XCTAssertFalse(defaults[.key])
+		Defaults[.key] = true
+		XCTAssertTrue(Defaults[.key])
+		Defaults.clear()
+		XCTAssertFalse(Defaults[.key])
 	}
 }

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -9,10 +9,10 @@ enum FixtureEnum: String, Codable {
 	case oneHour = "1 Hour"
 }
 
-extension DefaultsKeys {
-	static let key = DefaultsKey<Bool>("key", default: false)
-	static let url = DefaultsKey<URL>("url", default: fixtureUrl)
-	static let `enum` = DefaultsKey<FixtureEnum>("enum", default: .oneHour)
+extension UserDefaults.Keys {
+	static let key = UserDefaults.Key<Bool>("key", default: false)
+	static let url = UserDefaults.Key<URL>("url", default: fixtureUrl)
+	static let `enum` = UserDefaults.Key<FixtureEnum>("enum", default: .oneHour)
 }
 
 final class DefaultsTests: XCTestCase {
@@ -22,14 +22,14 @@ final class DefaultsTests: XCTestCase {
 	}
 
 	func testKey() {
-		let key = DefaultsKey<Bool>("key", default: false)
+		let key = UserDefaults.Key<Bool>("key", default: false)
 		XCTAssertFalse(UserDefaults.standard[key])
 		UserDefaults.standard[key] = true
 		XCTAssertTrue(UserDefaults.standard[key])
 	}
 
 	func testOptionalKey() {
-		let key = DefaultsOptionalKey<Bool>("key")
+		let key = UserDefaults.OptionalKey<Bool>("key")
 		XCTAssertNil(UserDefaults.standard[key])
 		UserDefaults.standard[key] = true
 		XCTAssertTrue(UserDefaults.standard[key]!)


### PR DESCRIPTION
I'ts not clear to me why you need the Defaults struct?

What do you think about removing it and keeping all methods on UserDefaults instead?

This breaks the API (but could be done without breaking it if preferred..):
- Defaults.Keys is renamed to DefaultsKeys
- Defaults.Key is renamed to DefaultsKey
- Defaults.OptionalKey is renamed to DefaultsOptionalKey
- The global shortcut `defaults` is renamed to `Defaults`.