### PR TITLE
Add `DefaultsObsevation.tieToLifetime(of:)`

### DIFF
--- a/Defaults.xcodeproj/xcshareddata/xcschemes/Defaults-iOS.xcscheme
+++ b/Defaults.xcodeproj/xcshareddata/xcschemes/Defaults-iOS.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "52D6D97B1BEFF229002C0205"
+            BuildableName = "Defaults.framework"
+            BlueprintName = "Defaults-iOS"
+            ReferencedContainer = "container:Defaults.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -41,17 +50,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "52D6D97B1BEFF229002C0205"
-            BuildableName = "Defaults.framework"
-            BlueprintName = "Defaults-iOS"
-            ReferencedContainer = "container:Defaults.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -72,8 +70,6 @@
             ReferencedContainer = "container:Defaults.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -4,8 +4,22 @@ import Foundation
 public protocol DefaultsObservation: AnyObject {
 	func invalidate()
 
+	/**
+	Keep this observation alive for as long as, and no longer than, another
+	object exists.
+
+	```
+	defaults.observe(.xyz) { [unowned self] change in
+		self.xyz = change.newValue
+	}.tieToLifetime(of: self)
+	```
+	*/
 	@discardableResult
 	func tieToLifetime(of weaklyHeldObject: AnyObject) -> Self
+	/**
+	Break the lifetime tie created by `tieToLifetime(of:)`, if one exists.
+	- Postcondition: As if `tieToLifetime(of:)` was never called on self.
+	*/
 	func removeLifetimeTie()
 }
 

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 /// TODO: Nest this inside `Defaults` if Swift ever supported nested protocols.
-public protocol DefaultsObservation: NSObjectProtocol {
+public protocol DefaultsObservation: AnyObject {
 	func invalidate()
 
 	@discardableResult
-	func tieToLifetimeOf(_ weaklyHeldObject: AnyObject) -> DefaultsObservation
+	func tieToLifetime(of weaklyHeldObject: AnyObject) -> Self
 	func removeLifetimeTie()
 }
 
@@ -109,7 +109,7 @@ extension Defaults {
 		private var lifetimeTie: LifetimeTie?
 		private static var lifetimeTieAssociationKey = AssociatedObject<UserDefaultsKeyObservation>()
 
-		public func tieToLifetimeOf(_ weaklyHeldObject: AnyObject) -> DefaultsObservation {
+		public func tieToLifetime(of weaklyHeldObject: AnyObject) -> Self {
 			UserDefaultsKeyObservation.lifetimeTieAssociationKey[weaklyHeldObject] = self
 			lifetimeTie = LifetimeTie(object: weaklyHeldObject)
 			return self

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -15,8 +15,10 @@ public protocol DefaultsObservation: AnyObject {
 	*/
 	@discardableResult
 	func tieToLifetime(of weaklyHeldObject: AnyObject) -> Self
+
 	/**
 	Break the lifetime tie created by `tieToLifetime(of:)`, if one exists.
+
 	- Postcondition: The effects of any call to `tieToLifetime(of:)` are reversed.
 	- Note: If the tied-to object has already died, then self is considered to be invalidated, and this method has no logical effect.
 	*/

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -120,14 +120,14 @@ extension Defaults {
 
 		private var lifetimeAssociation: LifetimeAssociation? = nil
 
-		func tieToLifetime(of weaklyHeldObject: AnyObject) -> Self {
+		public func tieToLifetime(of weaklyHeldObject: AnyObject) -> Self {
 			lifetimeAssociation = LifetimeAssociation(of: self, with: weaklyHeldObject, deinitHandler: { [weak self] in
 				self?.invalidate()
 			})
 			return self
 		}
 
-		func removeLifetimeTie() {
+		public func removeLifetimeTie() {
 			lifetimeAssociation?.cancel()
 		}
 

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -140,6 +140,7 @@ extension Defaults {
 				invalidate()
 				return
 			}
+
 			guard
 				selfObject == object as? NSObject,
 				let change = change

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -5,8 +5,7 @@ public protocol DefaultsObservation: AnyObject {
 	func invalidate()
 
 	/**
-	Keep this observation alive for as long as, and no longer than, another
-	object exists.
+	Keep this observation alive for as long as, and no longer than, another object exists.
 
 	```
 	defaults.observe(.xyz) { [unowned self] change in
@@ -19,8 +18,7 @@ public protocol DefaultsObservation: AnyObject {
 	/**
 	Break the lifetime tie created by `tieToLifetime(of:)`, if one exists.
 	- Postcondition: The effects of any call to `tieToLifetime(of:)` are reversed.
-	- Note: If the tied-to object has already died, then self is considered to be
-			invalidated, and this method has no logical effect.
+	- Note: If the tied-to object has already died, then self is considered to be invalidated, and this method has no logical effect.
 	*/
 	func removeLifetimeTie()
 }

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// TODO: Nest this inside `Defaults` if Swift ever supported nested protocols.
-public protocol DefaultsObservation {
+public protocol DefaultsObservation: NSObjectProtocol {
 	func invalidate()
 
 	@discardableResult

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -8,7 +8,7 @@ public protocol DefaultsObservation: AnyObject {
 	Keep this observation alive for as long as, and no longer than, another object exists.
 
 	```
-	defaults.observe(.xyz) { [unowned self] change in
+	Defaults.observe(.xyz) { [unowned self] change in
 		self.xyz = change.newValue
 	}.tieToLifetime(of: self)
 	```

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -18,7 +18,9 @@ public protocol DefaultsObservation: AnyObject {
 	func tieToLifetime(of weaklyHeldObject: AnyObject) -> Self
 	/**
 	Break the lifetime tie created by `tieToLifetime(of:)`, if one exists.
-	- Postcondition: As if `tieToLifetime(of:)` was never called on self.
+	- Postcondition: The effects of any call to `tieToLifetime(of:)` are reversed.
+	- Note: If the tied-to object has already died, then self is considered to be
+			invalidated, and this method has no logical effect.
 	*/
 	func removeLifetimeTie()
 }

--- a/Sources/Defaults/util.swift
+++ b/Sources/Defaults/util.swift
@@ -60,7 +60,7 @@ final class LifetimeAssociation {
 		var association: LifetimeAssociation?
 
 		func haunt(_ host: Furniture) {
-			association = LifetimeAssociation(of: self, with: host) { [weak self]
+			association = LifetimeAssociation(of: self, with: host) { [weak self] in
 				// Host has been deinitialized
 				self?.haunt(seekHost())
 			}

--- a/Sources/Defaults/util.swift
+++ b/Sources/Defaults/util.swift
@@ -28,39 +28,91 @@ final class AssociatedObject<T: Any> {
 	}
 }
 
-class LifetimeAssociation {
-	private(set) weak var object: AnyObject?
-	private(set) weak var owner: AnyObject?
-
-	fileprivate init(object weaklyHeldObject: AnyObject, owner weaklyHeldOwner: AnyObject) {
-		self.object = weaklyHeldObject
-		self.owner = weaklyHeldOwner
+/**
+Causes a given target object to live at least as long as a given owner object.
+*/
+final class LifetimeAssociation {
+	private class ObjectLifetimeTracker {
+		var object: AnyObject?
+		var deinitHandler: () -> Void
+		init(for weaklyHeldObject: AnyObject, deinitHandler: @escaping () -> Void) {
+			self.object = weaklyHeldObject
+			self.deinitHandler = deinitHandler
+		}
+		deinit {
+			deinitHandler()
+		}
 	}
 
-	/// Whether the owner is still alive and thus keeping its associated object alive.
-	var isValid: Bool {
-		return owner != nil
+	private static let associatedObjects = AssociatedObject<[ObjectLifetimeTracker]>()
+
+	private weak var wrappedObject: ObjectLifetimeTracker?
+	private weak var owner: AnyObject?
+
+	/**
+	Causes the given target object to live at least as long as either
+	the given owner object or the resulting `LifetimeAssociation`, whichever
+	is deallocated first.
+
+	When either the owner or the new `LifetimeAssociation` is destroyed, the
+	given deinit handler, if any, is called.
+
+	```
+	class Ghost {
+		var association: LifetimeAssociation?
+		func haunt(_ host: Furniture) {
+			association = LifetimeAssociation(of: self, with: host) { [weak self]
+				// host has been deinitialized
+				self?.haunt(seekHost())
+			}
+		}
+	}
+
+	let piano = Piano()
+	Ghost().haunt(piano)
+	// The Ghost will remain alive as long as `piano` remains alive.
+	```
+
+	- Parameter target: The object whose lifetime will be extended.
+	- Parameter owner: The object whose lifetime extends the target
+					   object's lifetime.
+	- Parameter deinitHandler: An optional closure to call when either `owner`
+							   or the resulting `LifetimeAssociation` is deallocated.
+	*/
+	init(of target: AnyObject, with owner: AnyObject, deinitHandler: @escaping () -> Void = { }) {
+		let wrappedObject = ObjectLifetimeTracker(for: target, deinitHandler: deinitHandler)
+		
+		let associatedObjects = LifetimeAssociation.associatedObjects[owner] ?? []
+		LifetimeAssociation.associatedObjects[owner] = associatedObjects + [wrappedObject]
+		
+		self.wrappedObject = wrappedObject
+		self.owner = owner
+	}
+
+	/**
+	Invalidates the association, unlinking the target object's lifetime from
+	that of the owner object. The provided deinit handler is not called.
+	*/
+	func cancel() {
+		wrappedObject?.deinitHandler = { }
+		invalidate()
 	}
 
 	deinit {
+		invalidate()
+	}
+
+	private func invalidate() {
 		guard
 			let owner = owner,
-			var associatedObjects = LifetimeAssociationKeys.associatedObjects[owner],
-			let objectIndex = associatedObjects.firstIndex(where: { $0 === object })
+			let wrappedObject = wrappedObject,
+			var associatedObjects = LifetimeAssociation.associatedObjects[owner],
+			let wrappedObjectAssociationIndex = associatedObjects.firstIndex(where: { $0 === wrappedObject })
 		else {
 			return
 		}
-		associatedObjects.remove(at: objectIndex)
-		LifetimeAssociationKeys.associatedObjects[owner] = associatedObjects
+		associatedObjects.remove(at: wrappedObjectAssociationIndex)
+		LifetimeAssociation.associatedObjects[owner] = associatedObjects
+		self.owner = nil
 	}
-}
-
-private struct LifetimeAssociationKeys {
-	static let associatedObjects = AssociatedObject<[AnyObject]>()
-}
-
-func associate(_ object: AnyObject, with owner: AnyObject) -> LifetimeAssociation {
-	let associatedObjects = LifetimeAssociationKeys.associatedObjects[owner] ?? []
-	LifetimeAssociationKeys.associatedObjects[owner] = associatedObjects + [object]
-	return LifetimeAssociation(object: object, owner: owner)
 }

--- a/Sources/Defaults/util.swift
+++ b/Sources/Defaults/util.swift
@@ -35,34 +35,33 @@ final class LifetimeAssociation {
 	private class ObjectLifetimeTracker {
 		var object: AnyObject?
 		var deinitHandler: () -> Void
+
 		init(for weaklyHeldObject: AnyObject, deinitHandler: @escaping () -> Void) {
 			self.object = weaklyHeldObject
 			self.deinitHandler = deinitHandler
 		}
+
 		deinit {
 			deinitHandler()
 		}
 	}
 
 	private static let associatedObjects = AssociatedObject<[ObjectLifetimeTracker]>()
-
 	private weak var wrappedObject: ObjectLifetimeTracker?
 	private weak var owner: AnyObject?
 
 	/**
-	Causes the given target object to live at least as long as either
-	the given owner object or the resulting `LifetimeAssociation`, whichever
-	is deallocated first.
+	Causes the given target object to live at least as long as either the given owner object or the resulting `LifetimeAssociation`, whichever is deallocated first.
 
-	When either the owner or the new `LifetimeAssociation` is destroyed, the
-	given deinit handler, if any, is called.
+	When either the owner or the new `LifetimeAssociation` is destroyed, the given deinit handler, if any, is called.
 
 	```
 	class Ghost {
 		var association: LifetimeAssociation?
+
 		func haunt(_ host: Furniture) {
 			association = LifetimeAssociation(of: self, with: host) { [weak self]
-				// host has been deinitialized
+				// Host has been deinitialized
 				self?.haunt(seekHost())
 			}
 		}
@@ -74,10 +73,8 @@ final class LifetimeAssociation {
 	```
 
 	- Parameter target: The object whose lifetime will be extended.
-	- Parameter owner: The object whose lifetime extends the target
-					   object's lifetime.
-	- Parameter deinitHandler: An optional closure to call when either `owner`
-							   or the resulting `LifetimeAssociation` is deallocated.
+	- Parameter owner: The object whose lifetime extends the target object's lifetime.
+	- Parameter deinitHandler: An optional closure to call when either `owner` or the resulting `LifetimeAssociation` is deallocated.
 	*/
 	init(of target: AnyObject, with owner: AnyObject, deinitHandler: @escaping () -> Void = { }) {
 		let wrappedObject = ObjectLifetimeTracker(for: target, deinitHandler: deinitHandler)
@@ -90,8 +87,7 @@ final class LifetimeAssociation {
 	}
 
 	/**
-	Invalidates the association, unlinking the target object's lifetime from
-	that of the owner object. The provided deinit handler is not called.
+	Invalidates the association, unlinking the target object's lifetime from that of the owner object. The provided deinit handler is not called.
 	*/
 	func cancel() {
 		wrappedObject?.deinitHandler = { }
@@ -111,6 +107,7 @@ final class LifetimeAssociation {
 		else {
 			return
 		}
+
 		associatedObjects.remove(at: wrappedObjectAssociationIndex)
 		LifetimeAssociation.associatedObjects[owner] = associatedObjects
 		self.owner = nil

--- a/Sources/Defaults/util.swift
+++ b/Sources/Defaults/util.swift
@@ -90,7 +90,7 @@ final class LifetimeAssociation {
 	Invalidates the association, unlinking the target object's lifetime from that of the owner object. The provided deinit handler is not called.
 	*/
 	func cancel() {
-		wrappedObject?.deinitHandler = { }
+		wrappedObject?.deinitHandler = {}
 		invalidate()
 	}
 

--- a/Sources/Defaults/util.swift
+++ b/Sources/Defaults/util.swift
@@ -17,3 +17,13 @@ extension Decodable {
 		self.init(jsonData: data)
 	}
 }
+
+final class AssociatedObject<T: Any> {
+	subscript(index: Any) -> T? {
+		get {
+			return objc_getAssociatedObject(index, Unmanaged.passUnretained(self).toOpaque()) as! T?
+		} set {
+			objc_setAssociatedObject(index, Unmanaged.passUnretained(self).toOpaque(), newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+		}
+	}
+}

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -271,4 +271,24 @@ final class DefaultsTests: XCTestCase {
 
 		waitForExpectations(timeout: 10)
 	}
+
+	func testObserveWithLifetimeTieManualBreak() {
+		let key = Defaults.Key<Bool>("lifetimeTieManualBreak", default: false)
+		let expect = expectation(description: "Observation closure being called")
+
+		weak var observation: DefaultsObservation? =
+			defaults.observe(key, options: []) { _ in }.tieToLifetimeOf(self)
+		observation!.removeLifetimeTie()
+
+		for _ in 0..<10 {
+			if observation == nil {
+				expect.fulfill()
+				break
+			} else {
+				sleep(1)
+			}
+		}
+
+		waitForExpectations(timeout: 10)
+	}
 }

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -264,7 +264,9 @@ final class DefaultsTests: XCTestCase {
 		expect.expectedFulfillmentCount = 2
 
 		autoreleasepool {
-			let object = NSObject()
+			// This *must* be autoreleasing… (for testing purposes)
+			let object = "hello \(className)" as NSString
+			
 			defaults.observe(key) { change in
 				expect.fulfill()
 			}.tieToLifetimeOf(object)
@@ -286,7 +288,9 @@ final class DefaultsTests: XCTestCase {
 		// Once from option .initial, twice from inside autoreleasepool block
 		expect.expectedFulfillmentCount = 3
 
-		let object = NSObject()
+		// This *must* be autoreleasing… (for testing purposes)
+		let object = "hello \(className)" as NSString
+		
 		autoreleasepool {
 			let observation = defaults.observe(key) { change in
 				expect.fulfill()

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -262,12 +262,12 @@ final class DefaultsTests: XCTestCase {
 		let expect = expectation(description: "Observation closure being called")
 
 		weak var observation: DefaultsObservation!
-		observation = defaults.observe(key, options: []) { change in
+		observation = Defaults.observe(key, options: []) { change in
 			observation.invalidate()
 			expect.fulfill()
 		}.tieToLifetime(of: self)
 
-		defaults[key] = true
+		Defaults[key] = true
 
 		waitForExpectations(timeout: 10)
 	}
@@ -276,7 +276,7 @@ final class DefaultsTests: XCTestCase {
 		let key = Defaults.Key<Bool>("lifetimeTieManualBreak", default: false)
 
 		weak var observation: DefaultsObservation? =
-			defaults.observe(key, options: []) { _ in }.tieToLifetime(of: self)
+			Defaults.observe(key, options: []) { _ in }.tieToLifetime(of: self)
 		observation!.removeLifetimeTie()
 
 		for i in 1...10 {

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -265,7 +265,7 @@ final class DefaultsTests: XCTestCase {
 		observation = defaults.observe(key, options: []) { change in
 			observation.invalidate()
 			expect.fulfill()
-		}.tieToLifetimeOf(self)
+		}.tieToLifetime(of: self)
 
 		defaults[key] = true
 
@@ -274,21 +274,19 @@ final class DefaultsTests: XCTestCase {
 
 	func testObserveWithLifetimeTieManualBreak() {
 		let key = Defaults.Key<Bool>("lifetimeTieManualBreak", default: false)
-		let expect = expectation(description: "Observation closure being called")
 
 		weak var observation: DefaultsObservation? =
-			defaults.observe(key, options: []) { _ in }.tieToLifetimeOf(self)
+			defaults.observe(key, options: []) { _ in }.tieToLifetime(of: self)
 		observation!.removeLifetimeTie()
 
-		for _ in 0..<10 {
+		for i in 1...10 {
 			if observation == nil {
-				expect.fulfill()
 				break
-			} else {
-				sleep(1)
+			}
+			sleep(1)
+			if i == 10 {
+				XCTFail()
 			}
 		}
-
-		waitForExpectations(timeout: 10)
 	}
 }

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -275,15 +275,16 @@ final class DefaultsTests: XCTestCase {
 	func testObserveWithLifetimeTieManualBreak() {
 		let key = Defaults.Key<Bool>("lifetimeTieManualBreak", default: false)
 
-		weak var observation: DefaultsObservation? =
-			Defaults.observe(key, options: []) { _ in }.tieToLifetime(of: self)
+		weak var observation: DefaultsObservation? = Defaults.observe(key, options: []) { _ in }.tieToLifetime(of: self)
 		observation!.removeLifetimeTie()
 
 		for i in 1...10 {
 			if observation == nil {
 				break
 			}
+
 			sleep(1)
+
 			if i == 10 {
 				XCTFail()
 			}

--- a/readme.md
+++ b/readme.md
@@ -149,13 +149,18 @@ extension Defaults.Keys {
 	static let isUnicornMode = Key<Bool>("isUnicornMode", default: false)
 }
 
-Defaults.observe(.isUnicornMode) { change in
-	print(change.oldValue)
-	print(change.newValue)
-}.tieToLifetime(of: self)
+final class Foo {
+	init() {
+		Defaults.observe(.isUnicornMode) { change in
+			print(change.oldValue)
+			print(change.newValue)
+		}.tieToLifetime(of: self)
+	}
+}
 
 Defaults[.isUnicornMode] = true
 ```
+
 The observation will be valid until `self` is deinitialized.
 
 ### Reset keys to their default values

--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,22 @@ Defaults[.isUnicornMode] = true
 
 In contrast to the native `UserDefaults` key observation, here you receive a strongly-typed change object.
 
+### Automatic observation invalidation
+
+```swift
+extension Defaults.Keys {
+	static let isUnicornMode = Key<Bool>("isUnicornMode", default: false)
+}
+
+Defaults.observe(.isUnicornMode) { change in
+	print(change.oldValue)
+	print(change.newValue)
+}.tieToLifetime(of: self)
+
+Defaults[.isUnicornMode] = true
+```
+The observation will be valid until `self` is deinitialized.
+
 ### Reset keys to their default values
 
 ```swift

--- a/readme.md
+++ b/readme.md
@@ -142,7 +142,7 @@ Defaults[.isUnicornMode] = true
 
 In contrast to the native `UserDefaults` key observation, here you receive a strongly-typed change object.
 
-### Automatic observation invalidation
+### Invalidate observations automatically
 
 ```swift
 extension Defaults.Keys {
@@ -299,6 +299,47 @@ Defaults.removeAll(suite: UserDefaults = .standard)
 Type: `func`
 
 Remove all entries from the `UserDefaults` suite.
+
+### `DefaultsObservation`
+
+Type: `protocol`
+
+Represents an observation of a defaults key.
+
+#### `DefaultsObservation.invalidate`
+
+```swift
+DefaultsObservation.invalidate()
+```
+
+Type: `func`
+
+Invalidate the observation.
+
+#### `DefaultsObservation.tieToLifetime`
+
+```swift
+@discardableResult
+DefaultsObservation.tieToLifetime(of weaklyHeldObject: AnyObject) -> Self
+```
+
+Type: `func`
+
+Keep the observation alive for as long as, and no longer than, another object exists.
+
+When `weaklyHeldObject` is deinitialized, the observation is invalidated automatically.
+
+#### `DefaultsObservation.removeLifetimeTie`
+
+```swift
+DefaultsObservation.removeLifetimeTie()
+```
+
+Type: `func`
+
+Break the lifetime tie created by `tieToLifetime(of:)`, if one exists.
+
+The effects of any call to `tieToLifetime(of:)` are reversed. Note however that if the tied-to object has already died, then the observation is already invalid and this method has no logical effect.
 
 
 ## FAQ


### PR DESCRIPTION
Strongly associates the observation with the passed-in object. It then lives for at least as long as the object, and automatically invalidates either a) once no more references to it exist, or b) when it receives a notification and realizes that the object to which it was tied has died.