### PR TITLE
Add ability to subscribe to multiple keys and to prevent propagation

### DIFF
--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -14,6 +14,8 @@ extension DefaultsBaseKey {
 }
 
 public enum Defaults {
+	public typealias BaseKey = DefaultsBaseKey
+	
 	public class Keys {
 		public typealias Key = Defaults.Key
 
@@ -26,7 +28,7 @@ public enum Defaults {
 		fileprivate init() {}
 	}
 
-	public final class Key<Value: Codable>: Keys, DefaultsBaseKey {
+	public final class Key<Value: Codable>: Keys, BaseKey {
 		public let name: String
 		public let defaultValue: Value
 		public let suite: UserDefaults
@@ -53,7 +55,7 @@ public enum Defaults {
 	}
 
 	@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
-	public final class NSSecureCodingKey<Value: NSSecureCoding>: Keys, DefaultsBaseKey {
+	public final class NSSecureCodingKey<Value: NSSecureCoding>: Keys, BaseKey {
 		public let name: String
 		public let defaultValue: Value
 		public let suite: UserDefaults
@@ -80,7 +82,7 @@ public enum Defaults {
 	}
 
 	@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
-	public final class NSSecureCodingOptionalKey<Value: NSSecureCoding>: Keys, DefaultsBaseKey {
+	public final class NSSecureCodingOptionalKey<Value: NSSecureCoding>: Keys, BaseKey {
 		public let name: String
 		public let suite: UserDefaults
 

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -16,7 +16,7 @@ extension DefaultsBaseKey {
 public enum Defaults {
 	public typealias BaseKey = DefaultsBaseKey
 	
-	public class Keys {
+	public class Keys: BaseKey {
 		public typealias Key = Defaults.Key
 
 		@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
@@ -25,21 +25,22 @@ public enum Defaults {
 		@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
 		public typealias NSSecureCodingOptionalKey = Defaults.NSSecureCodingOptionalKey
 
-		fileprivate init() {}
+		public let name: String
+		public let suite: UserDefaults
+		fileprivate init(name: String, suite: UserDefaults) {
+			self.name = name
+			self.suite = suite
+		}
 	}
 
-	public final class Key<Value: Codable>: Keys, BaseKey {
-		public let name: String
+	public final class Key<Value: Codable>: Keys {
 		public let defaultValue: Value
-		public let suite: UserDefaults
 
 		/// Create a defaults key.
 		public init(_ key: String, default defaultValue: Value, suite: UserDefaults = .standard) {
-			self.name = key
 			self.defaultValue = defaultValue
-			self.suite = suite
 
-			super.init()
+			super.init(name: key, suite: suite)
 
 			if (defaultValue as? _DefaultsOptionalType)?.isNil == true {
 				return
@@ -55,18 +56,14 @@ public enum Defaults {
 	}
 
 	@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
-	public final class NSSecureCodingKey<Value: NSSecureCoding>: Keys, BaseKey {
-		public let name: String
+	public final class NSSecureCodingKey<Value: NSSecureCoding>: Keys {
 		public let defaultValue: Value
-		public let suite: UserDefaults
 
 		/// Create a defaults key.
 		public init(_ key: String, default defaultValue: Value, suite: UserDefaults = .standard) {
-			self.name = key
 			self.defaultValue = defaultValue
-			self.suite = suite
 
-			super.init()
+			super.init(name: key, suite: suite)
 
 			if (defaultValue as? _DefaultsOptionalType)?.isNil == true {
 				return
@@ -82,14 +79,10 @@ public enum Defaults {
 	}
 
 	@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
-	public final class NSSecureCodingOptionalKey<Value: NSSecureCoding>: Keys, BaseKey {
-		public let name: String
-		public let suite: UserDefaults
-
+	public final class NSSecureCodingOptionalKey<Value: NSSecureCoding>: Keys {
 		/// Create an optional defaults key.
 		public init(_ key: String, suite: UserDefaults = .standard) {
-			self.name = key
-			self.suite = suite
+			super.init(name: key, suite: suite)
 		}
 	}
 

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -27,6 +27,7 @@ public enum Defaults {
 
 		public let name: String
 		public let suite: UserDefaults
+
 		fileprivate init(name: String, suite: UserDefaults) {
 			self.name = name
 			self.suite = suite

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -1,12 +1,12 @@
 // MIT License © Sindre Sorhus
 import Foundation
 
-public protocol _DefaultsBaseKey: Defaults.Keys {
+public protocol DefaultsBaseKey: Defaults.Keys {
 	var name: String { get }
 	var suite: UserDefaults { get }
 }
 
-extension _DefaultsBaseKey {
+extension DefaultsBaseKey {
 	/// Reset the item back to its default value.
 	public func reset() {
 		suite.removeObject(forKey: name)
@@ -26,7 +26,7 @@ public enum Defaults {
 		fileprivate init() {}
 	}
 
-	public final class Key<Value: Codable>: Keys, _DefaultsBaseKey {
+	public final class Key<Value: Codable>: Keys, DefaultsBaseKey {
 		public let name: String
 		public let defaultValue: Value
 		public let suite: UserDefaults
@@ -53,7 +53,7 @@ public enum Defaults {
 	}
 
 	@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
-	public final class NSSecureCodingKey<Value: NSSecureCoding>: Keys, _DefaultsBaseKey {
+	public final class NSSecureCodingKey<Value: NSSecureCoding>: Keys, DefaultsBaseKey {
 		public let name: String
 		public let defaultValue: Value
 		public let suite: UserDefaults
@@ -80,7 +80,7 @@ public enum Defaults {
 	}
 
 	@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
-	public final class NSSecureCodingOptionalKey<Value: NSSecureCoding>: Keys, _DefaultsBaseKey {
+	public final class NSSecureCodingOptionalKey<Value: NSSecureCoding>: Keys, DefaultsBaseKey {
 		public let name: String
 		public let suite: UserDefaults
 

--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -133,7 +133,7 @@ extension Defaults {
 	*/
 	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
 	public static func publisher(
-		keys: BaseKey...,
+		keys: Keys...,
 		options: ObservationOptions = [.initial]
 	) -> AnyPublisher<Void, Never> {
 		let initial = Empty<Void, Never>(completeImmediately: false).eraseToAnyPublisher()

--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -133,7 +133,7 @@ extension Defaults {
 	*/
 	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
 	public static func publisher(
-		keys: _DefaultsBaseKey...,
+		keys: DefaultsBaseKey...,
 		options: ObservationOptions = [.initial]
 	) -> AnyPublisher<Void, Never> {
 		let initial = Empty<Void, Never>(completeImmediately: false).eraseToAnyPublisher()

--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -133,7 +133,7 @@ extension Defaults {
 	*/
 	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
 	public static func publisher(
-		keys: DefaultsBaseKey...,
+		keys: BaseKey...,
 		options: ObservationOptions = [.initial]
 	) -> AnyPublisher<Void, Never> {
 		let initial = Empty<Void, Never>(completeImmediately: false).eraseToAnyPublisher()

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -208,7 +208,7 @@ extension Defaults {
 	final class CompositeUserDefaultsKeyObservation: NSObject, Observation {
 		private static var observationContext = 0
 		
-		class SuiteKeyPair {
+		final class SuiteKeyPair {
 			weak var suite: UserDefaults?
 			let key: String
 			

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -365,7 +365,7 @@ extension Defaults {
 	}
 	
 	public static func observe(
-		keys: _DefaultsBaseKey...,
+		keys: DefaultsBaseKey...,
 		options: ObservationOptions = [.initial],
 		preventPropagation: Bool = false,
 		handler: @escaping () -> Void

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -152,7 +152,7 @@ extension Defaults {
 		Thread.current.threadDictionary[key] = false
 	}
 
-	private final class UserDefaultsKeyObservation: NSObject, Observation {
+	final class UserDefaultsKeyObservation: NSObject, Observation {
 		typealias Callback = (BaseChange) -> Void
 
 		private weak var object: UserDefaults?
@@ -380,7 +380,7 @@ extension Defaults {
 	
 	*/
 	public static func observe(
-		keys: BaseKey...,
+		keys: Keys...,
 		options: ObservationOptions = [.initial],
 		handler: @escaping () -> Void
 	) -> Observation {

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -368,7 +368,7 @@ extension Defaults {
 	}
 	
 	public static func observe(
-		keys: DefaultsBaseKey...,
+		keys: BaseKey...,
 		options: ObservationOptions = [.initial],
 		preventPropagation: Bool = false,
 		handler: @escaping () -> Void

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -223,8 +223,8 @@ extension Defaults {
 		private let preventPropagation: Bool
 		private let callback: UserDefaultsKeyObservation.Callback
 		
-		init(observables: [SuiteKeyPair], preventPropagation: Bool, callback: @escaping UserDefaultsKeyObservation.Callback) {
-			self.observables = observables
+		init(observables: [(suite: UserDefaults, key: String)], preventPropagation: Bool, callback: @escaping UserDefaultsKeyObservation.Callback) {
+			self.observables = observables.map { SuiteKeyPair(suite: $0.suite, key: $0.key) }
 			self.preventPropagation = preventPropagation
 			self.callback = callback
 			super.init()
@@ -374,7 +374,7 @@ extension Defaults {
 		handler: @escaping () -> Void
 	) -> Observation {
 		let pairs = keys.map {
-			CompositeUserDefaultsKeyObservation.SuiteKeyPair(suite: $0.suite, key: $0.name)
+			(suite: $0.suite, key: $0.name)
 		}
 		let compositeObservation = CompositeUserDefaultsKeyObservation(observables: pairs, preventPropagation: preventPropagation) { _ in
 			handler()

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -150,9 +150,9 @@ extension Defaults {
 	
 	Example:
 	```
-	Defaults.observeAll(.key1, .key2) {
+	let observer = Defaults.observe(keys: .key1, .key2) {
 		// …
-		withoutPropagation {
+		Defaults.withoutPropagation {
 			// update some value at .key1
 			// this will not be propagated
 			Defaults[.key1] = 11

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -141,18 +141,18 @@ extension Defaults {
 		}
 	}
 	
-	static var preventPropagationThreadDictKey: String {
-		return "\(type(of: Observation.self))_threadUpdatingValuesFlag"
+	private static var preventPropagationThreadDictKey: String {
+		"\(type(of: Observation.self))_threadUpdatingValuesFlag"
 	}
 	
 	public static func withoutPropagation(block: () -> Void) {
-		let key = Defaults.preventPropagationThreadDictKey
+		let key = preventPropagationThreadDictKey
 		Thread.current.threadDictionary[key] = true
 		block()
 		Thread.current.threadDictionary[key] = false
 	}
 
-	final class UserDefaultsKeyObservation: NSObject, Observation {
+	private final class UserDefaultsKeyObservation: NSObject, Observation {
 		typealias Callback = (BaseChange) -> Void
 
 		private weak var object: UserDefaults?
@@ -212,10 +212,9 @@ extension Defaults {
 				return
 			}
 			
-			
 			let key = preventPropagationThreadDictKey
 			let updatingValuesFlag = (Thread.current.threadDictionary[key] as? Bool) ?? false
-			if updatingValuesFlag {
+			guard !updatingValuesFlag else {
 				return
 			}
 
@@ -223,10 +222,10 @@ extension Defaults {
 		}
 	}
 	
-	final class CompositeUserDefaultsKeyObservation: NSObject, Observation {
+	private final class CompositeUserDefaultsKeyObservation: NSObject, Observation {
 		private static var observationContext = 0
 		
-		final class SuiteKeyPair {
+		private final class SuiteKeyPair {
 			weak var suite: UserDefaults?
 			let key: String
 			
@@ -377,6 +376,9 @@ extension Defaults {
 		return observation
 	}
 	
+	/**
+	
+	*/
 	public static func observe(
 		keys: BaseKey...,
 		options: ObservationOptions = [.initial],

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -200,12 +200,12 @@ extension Defaults {
 			else {
 				return
 			}
-			
+
 			callback(BaseChange(change: change))
 		}
 	}
 	
-	class CompositeUserDefaultsKeyObservation: NSObject, Observation {
+	final class CompositeUserDefaultsKeyObservation: NSObject, Observation {
 		private static var observationContext = 0
 		
 		class SuiteKeyPair {
@@ -236,10 +236,12 @@ extension Defaults {
 		
 		public func start(options: ObservationOptions) {
 			for observable in observables {
-				observable.suite?.addObserver(self,
-											   forKeyPath: observable.key,
-											   options: options.toNSKeyValueObservingOptions,
-											   context: &type(of: self).observationContext)
+				observable.suite?.addObserver(
+					self,
+					forKeyPath: observable.key,
+					options: options.toNSKeyValueObservingOptions,
+					context: &type(of: self).observationContext
+				)
 			}
 		}
 		
@@ -248,6 +250,7 @@ extension Defaults {
 				observable.suite?.removeObserver(self, forKeyPath: observable.key, context: &type(of: self).observationContext)
 				observable.suite = nil
 			}
+
 			lifetimeAssociation?.cancel()
 		}
 		

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -218,13 +218,13 @@ extension Defaults {
 			}
 		}
 		
-		private var observations: [SuiteKeyPair]
+		private var observables: [SuiteKeyPair]
 		private var lifetimeAssociation: LifetimeAssociation? = nil
 		private let preventPropagation: Bool
 		private let callback: UserDefaultsKeyObservation.Callback
 		
-		init(observations: [SuiteKeyPair], preventPropagation: Bool, callback: @escaping UserDefaultsKeyObservation.Callback) {
-			self.observations = observations
+		init(observables: [SuiteKeyPair], preventPropagation: Bool, callback: @escaping UserDefaultsKeyObservation.Callback) {
+			self.observables = observables
 			self.preventPropagation = preventPropagation
 			self.callback = callback
 			super.init()
@@ -235,18 +235,18 @@ extension Defaults {
 		}
 		
 		public func start(options: ObservationOptions) {
-			for observation in observations {
-				observation.suite?.addObserver(self,
-											   forKeyPath: observation.key,
+			for observable in observables {
+				observable.suite?.addObserver(self,
+											   forKeyPath: observable.key,
 											   options: options.toNSKeyValueObservingOptions,
 											   context: &type(of: self).observationContext)
 			}
 		}
 		
 		public func invalidate() {
-			for observation in observations {
-				observation.suite?.removeObserver(self, forKeyPath: observation.key, context: &type(of: self).observationContext)
-				observation.suite = nil
+			for observable in observables {
+				observable.suite?.removeObserver(self, forKeyPath: observable.key, context: &type(of: self).observationContext)
+				observable.suite = nil
 			}
 			lifetimeAssociation?.cancel()
 		}
@@ -373,7 +373,7 @@ extension Defaults {
 		let pairs = keys.map {
 			CompositeUserDefaultsKeyObservation.SuiteKeyPair(suite: $0.suite, key: $0.name)
 		}
-		let compositeObservation = CompositeUserDefaultsKeyObservation(observations: pairs, preventPropagation: preventPropagation) { _ in
+		let compositeObservation = CompositeUserDefaultsKeyObservation(observables: pairs, preventPropagation: preventPropagation) { _ in
 			handler()
 		}
 		compositeObservation.start(options: options)

--- a/Sources/Defaults/Reset.swift
+++ b/Sources/Defaults/Reset.swift
@@ -5,7 +5,7 @@ TODO: When Swift gets support for static key paths, all of this could be simplif
 
 ```
 extension Defaults {
-	public static func reset(_ keys: KeyPath<Keys, _DefaultsBaseKey>...) {
+	public static func reset(_ keys: KeyPath<Keys, DefaultsBaseKey>...) {
 		for key in keys {
 			Keys[keyPath: key].reset()
 		}

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -535,6 +535,25 @@ final class DefaultsTests: XCTestCase {
 
 		waitForExpectations(timeout: 10)
 	}
+	
+//	func testObservePreventPropagation() {
+//		let key1 = Defaults.Key<Bool?>("preventPropagation", default: nil)
+//		let expect = expectation(description: "No infinite recursion")
+//
+//		var observation: Defaults.Observation!
+//		var wasInside = false
+//		observation = Defaults.observe(key1, options: []) { change in
+//			XCTAssertFalse(wasInside)
+//			wasInside = true
+//			Defaults[key1] = true
+//			expect.fulfill()
+//		}
+//
+//		Defaults[key1] = false
+//		observation.invalidate()
+//
+//		waitForExpectations(timeout: 10)
+//	}
 
 	func testResetKey() {
 		let defaultFixture1 = "foo1"

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -452,6 +452,53 @@ final class DefaultsTests: XCTestCase {
 
 		waitForExpectations(timeout: 10)
 	}
+	
+	func testObserveMultipleKeys() {
+		let key1 = Defaults.Key<String>("observeKey1", default: "x")
+		let key2 = Defaults.Key<Bool>("observeKey2", default: true)
+		let expect = expectation(description: "Observation closure being called")
+		
+		var observation: Defaults.Observation!
+		var counter = 0
+		observation = Defaults.observe(keys: key1, key2, options: []) {
+			counter += 1
+			if counter == 2 {
+				expect.fulfill()
+			} else if counter > 2 {
+				XCTFail()
+			}
+		}
+		
+		Defaults[key1] = "y"
+		Defaults[key2] = false
+		observation.invalidate()
+		
+		waitForExpectations(timeout: 10)
+	}
+	
+	@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
+	func testObserveMultipleNSSecureKeys() {
+		let key1 = Defaults.NSSecureCodingKey<ExamplePersistentHistory>("observeNSSecureCodingKey1", default: ExamplePersistentHistory(value: "TestValue"))
+		let key2 = Defaults.NSSecureCodingKey<ExamplePersistentHistory>("observeNSSecureCodingKey2", default: ExamplePersistentHistory(value: "TestValue"))
+		let expect = expectation(description: "Observation closure being called")
+		
+		var observation: Defaults.Observation!
+		var counter = 0
+		observation = Defaults.observe(keys: key1, key2, options: []) {
+			counter += 1
+			if counter == 2 {
+				expect.fulfill()
+			} else if counter > 2 {
+				XCTFail()
+			}
+		}
+		
+		Defaults[key1] = ExamplePersistentHistory(value: "NewTestValue1")
+		Defaults[key2] = ExamplePersistentHistory(value: "NewTestValue2")
+		observation.invalidate()
+
+		waitForExpectations(timeout: 10)
+	}
 
 	func testObserveKeyURL() {
 		let fixtureURL = URL(string: "https://sindresorhus.com")!

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -684,23 +684,21 @@ final class DefaultsTests: XCTestCase {
 		let expect = expectation(description: "No infinite recursion")
 		
 		var wasInside = false
-		let cancellable = Defaults.publisher(key1, options: [])
-			.subscribe(on: RunLoop.main)
-			.receive(on: DispatchQueue.global(qos: .userInitiated))
-			//.delay(for: 0.5, scheduler: DispatchQueue.global(qos: .background))
+		var cancellable: AnyCancellable!
+		cancellable = Defaults.publisher(key1, options: [])
+			.receive(on: DispatchQueue.global())
+			.delay(for: 0.5, scheduler: DispatchQueue.global())
 			.sink { _ in
 				XCTAssertFalse(wasInside)
 				wasInside = true
-				print("--=-= HEHE")
 				Defaults.withoutPropagation {
 					Defaults[key1] = true
 				}
-				print("--=-= HHHH")
 				expect.fulfill()
+				cancellable.cancel()
 			}
 		
 		Defaults[key1] = false
-		//cancellable.cancel()
 		
 		waitForExpectations(timeout: 10)
 	}

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -543,10 +543,12 @@ final class DefaultsTests: XCTestCase {
 
 		var observation: Defaults.Observation!
 		var wasInside = false
-		observation = Defaults.observe(keys: key1, key2, options: [], preventPropagation: true) {
+		observation = Defaults.observe(keys: key1, key2, options: []) {
 			XCTAssertFalse(wasInside)
 			wasInside = true
-			Defaults[key1] = true
+			Defaults.withoutPropagation {
+				Defaults[key1] = true
+			}
 			expect.fulfill()
 		}
 
@@ -563,8 +565,10 @@ final class DefaultsTests: XCTestCase {
 		var observation: Defaults.Observation!
 		// This checks if callback is still being called, if value is changed on second thread,
 		// while initial thread is doing some long lasting task.
-		observation = Defaults.observe(keys: key1, options: [], preventPropagation: true) {
-			Defaults[key1]! += 1
+		observation = Defaults.observe(keys: key1, options: []) {
+			Defaults.withoutPropagation {
+				Defaults[key1]! += 1
+			}
 			print("--- Main Thread: \(Thread.isMainThread)")
 			if !Thread.isMainThread {
 				XCTAssert(Defaults[key1]! == 4)

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -686,7 +686,7 @@ final class DefaultsTests: XCTestCase {
 		var wasInside = false
 		var cancellable: AnyCancellable!
 		cancellable = Defaults.publisher(key1, options: [])
-			.receive(on: DispatchQueue.global())
+			.receive(on: DispatchQueue.main)
 			.delay(for: 0.5, scheduler: DispatchQueue.global())
 			.sink { _ in
 				XCTAssertFalse(wasInside)

--- a/readme.md
+++ b/readme.md
@@ -235,6 +235,23 @@ Defaults[.isUnicornMode] = true
 
 The observation will be valid until `self` is deinitialized.
 
+### Control propagation of change events
+
+```swift
+let observer = Defaults.observe(keys: .key1, .key2) {
+	// …
+	Defaults.withoutPropagation {
+		// update some value at .key1
+		// this will not be propagated
+		Defaults[.key1] = 11
+	}
+	// this will be propagated
+	Defaults[.someKey] = true
+}
+```
+
+Changes made within `Defaults.withoutPropagation` block, will not be propagated to observation callbacks, and therefore will prevent infinite recursion.
+
 ### Reset keys to their default values
 
 ```swift
@@ -383,6 +400,14 @@ Observe changes to a key or an optional key.
 
 By default, it will also trigger an initial event on creation. This can be useful for setting default values on controls. You can override this behavior with the `options` argument.
 
+#### `Defaults.observe(keys: keys..., options:)`
+
+Type: `func`
+
+Observe changes to multiple keys of any type, but without specific information about changes.
+
+Options same as in  `observe` for a single key. 
+
 #### `Defaults.publisher(_ key:, options:)`
 
 ```swift
@@ -470,6 +495,12 @@ Type: `func`
 Break the lifetime tie created by `tieToLifetime(of:)`, if one exists.
 
 The effects of any call to `tieToLifetime(of:)` are reversed. Note however that if the tied-to object has already died, then the observation is already invalid and this method has no logical effect.
+
+#### `Defaults.withoutPropagation(_ block:)`
+
+Execute block without emitting events of changes made at defaults keys. 
+
+Changes made within the block will not be propagated to observation callbacks. This only works with defaults `observe` or `publisher`. User made KVO will not be affected.
 
 ### `@Default(_ key:)`
 


### PR DESCRIPTION
Attempt to fix #30

Added `CompositeUserDefaultsKeyObservation` for observing multiple keys, with `preventPropagation` option to prevent infinite recursion when change is made within handler. 

I store flag in threadDictionary of the current thread to determine when changes should be propagated. This enables to still support changes made on other threads, while initial one is still processing handler (more in `testObservePreventPropagationMultiThread` test case).

Code is still a little messy, but let me know what you think :)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#30: Add ability to subscribe to multiple keys or any change in a given suite](https://issuehunt.io/repos/129132562/issues/30)
---
</details>
<!-- /Issuehunt content-->