### PR TITLE
Support `.removeDuplicates()` for `Defaults.publisher`

### DIFF
--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -151,4 +151,24 @@ extension Defaults {
 		return combinedPublisher
 	}
 }
+
+@available(OSXApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
+extension Defaults.NSSecureCodingKeyChange: Equatable where Value: Equatable {
+	public static func == (lhs: Self, rhs: Self) -> Bool {
+		lhs.newValue == rhs.newValue
+	}
+}
+
+@available(OSXApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
+extension Defaults.NSSecureCodingOptionalKeyChange: Equatable where Value: Equatable {
+	public static func == (lhs: Self, rhs: Self) -> Bool {
+		lhs.newValue == rhs.newValue
+	}
+}
+
+extension Defaults.KeyChange: Equatable where Value: Equatable {
+	public static func == (lhs: Self, rhs: Self) -> Bool {
+		lhs.newValue == rhs.newValue
+	}
+}
 #endif

--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -152,14 +152,14 @@ extension Defaults {
 	}
 }
 
-@available(OSXApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
+@available(macOS 10.13, OSXApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
 extension Defaults.NSSecureCodingKeyChange: Equatable where Value: Equatable {
 	public static func == (lhs: Self, rhs: Self) -> Bool {
 		lhs.newValue == rhs.newValue
 	}
 }
 
-@available(OSXApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
+@available(macOS 10.13, OSXApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
 extension Defaults.NSSecureCodingOptionalKeyChange: Equatable where Value: Equatable {
 	public static func == (lhs: Self, rhs: Self) -> Bool {
 		lhs.newValue == rhs.newValue

--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -152,14 +152,14 @@ extension Defaults {
 	}
 }
 
-@available(macOS 10.13, OSXApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
+@available(macOS 10.13, macOSApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
 extension Defaults.NSSecureCodingKeyChange: Equatable where Value: Equatable {
 	public static func == (lhs: Self, rhs: Self) -> Bool {
 		lhs.newValue == rhs.newValue
 	}
 }
 
-@available(macOS 10.13, OSXApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
+@available(macOS 10.13, macOSApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
 extension Defaults.NSSecureCodingOptionalKeyChange: Equatable where Value: Equatable {
 	public static func == (lhs: Self, rhs: Self) -> Bool {
 		lhs.newValue == rhs.newValue

--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -151,24 +151,4 @@ extension Defaults {
 		return combinedPublisher
 	}
 }
-
-@available(macOS 10.13, macOSApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
-extension Defaults.NSSecureCodingKeyChange: Equatable where Value: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool {
-		lhs.newValue == rhs.newValue
-	}
-}
-
-@available(macOS 10.13, macOSApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
-extension Defaults.NSSecureCodingOptionalKeyChange: Equatable where Value: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool {
-		lhs.newValue == rhs.newValue
-	}
-}
-
-extension Defaults.KeyChange: Equatable where Value: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool {
-		lhs.newValue == rhs.newValue
-	}
-}
 #endif

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -446,3 +446,11 @@ extension Defaults.ObservationOptions {
 		return options
 	}
 }
+
+@available(macOS 10.13, macOSApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
+extension Defaults.NSSecureCodingKeyChange: Equatable where Value: Equatable { }
+
+@available(macOS 10.13, macOSApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
+extension Defaults.NSSecureCodingOptionalKeyChange: Equatable where Value: Equatable { }
+
+extension Defaults.KeyChange: Equatable where Value: Equatable { }

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -812,4 +812,117 @@ final class DefaultsTests: XCTestCase {
 			}
 		}
 	}
+
+	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
+	func testRemoveDuplicatesObserveKeyCombine() {
+		let key = Defaults.Key<Bool>("observeKey", default: false)
+		let expect = expectation(description: "Observation closure being called")
+
+		let inputArray = [true, false, false, false, false, false, false, true]
+		let expectedArray = [true, false, true]
+
+		let cancellable = Defaults
+			.publisher(key, options: [])
+			.removeDuplicates()
+			.map(\.newValue)
+			.collect(expectedArray.count)
+			.sink { result in
+				print("Result array: \(result)")
+				result == expectedArray ? expect.fulfill() : XCTFail("Expected Array is not matched")
+			}
+
+		inputArray.forEach {
+			Defaults[key] = $0
+		}
+
+		Defaults.reset(key)
+		cancellable.cancel()
+
+		waitForExpectations(timeout: 10)
+	}
+
+	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
+	func testRemoveDuplicatesOptionalObserveKeyCombine() {
+		let key = Defaults.Key<Bool?>("observeOptionalKey", default: nil)
+		let expect = expectation(description: "Observation closure being called")
+
+		let inputArray = [true, nil, nil, nil, false, false, false, nil]
+		let expectedArray = [true, nil, false, nil]
+
+		let cancellable = Defaults
+			.publisher(key, options: [])
+			.removeDuplicates()
+			.map(\.newValue)
+			.collect(expectedArray.count)
+			.sink { result in
+				print("Result array: \(result)")
+				result == expectedArray ? expect.fulfill() : XCTFail("Expected Array is not matched")
+			}
+
+		inputArray.forEach {
+			Defaults[key] = $0
+		}
+
+		Defaults.reset(key)
+		cancellable.cancel()
+
+		waitForExpectations(timeout: 10)
+	}
+
+	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
+	func testRemoveDuplicatesObserveNSSecureCodingKeyCombine() {
+		let key = Defaults.NSSecureCodingKey<ExamplePersistentHistory>("observeNSSecureCodingKey", default: ExamplePersistentHistory(value: "TestValue"))
+		let expect = expectation(description: "Observation closure being called")
+
+		let inputArray = ["NewTestValue", "NewTestValue", "NewTestValue", "NewTestValue2", "NewTestValue2", "NewTestValue2", "NewTestValue3", "NewTestValue3"]
+		let expectedArray = ["NewTestValue", "NewTestValue2", "NewTestValue3"]
+
+		let cancellable = Defaults
+			.publisher(key, options: [])
+			.removeDuplicates()
+			.map(\.newValue.value)
+			.collect(expectedArray.count)
+			.sink { result in
+				print("Result array: \(result)")
+				result == expectedArray ? expect.fulfill() : XCTFail("Expected Array is not matched")
+			}
+
+		inputArray.forEach {
+			Defaults[key] = ExamplePersistentHistory(value: $0)
+		}
+
+		Defaults.reset(key)
+		cancellable.cancel()
+
+		waitForExpectations(timeout: 10)
+	}
+
+	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
+	func testRemoveDuplicatesObserveNSSecureCodingOptionalKeyCombine() {
+		let key = Defaults.NSSecureCodingOptionalKey<ExamplePersistentHistory>("observeNSSecureCodingOptionalKey")
+		let expect = expectation(description: "Observation closure being called")
+
+		let inputArray = ["NewTestValue", "NewTestValue", "NewTestValue", "NewTestValue2", "NewTestValue2", "NewTestValue2", "NewTestValue3", "NewTestValue3"]
+		let expectedArray = ["NewTestValue", "NewTestValue2", "NewTestValue3", nil]
+
+		let cancellable = Defaults
+			.publisher(key, options: [])
+			.removeDuplicates()
+			.map(\.newValue)
+			.map { $0?.value }
+			.collect(expectedArray.count)
+			.sink { result in
+				print("Result array: \(result)")
+				result == expectedArray ? expect.fulfill() : XCTFail("Expected Array is not matched")
+			}
+
+		inputArray.forEach {
+			Defaults[key] = ExamplePersistentHistory(value: $0)
+		}
+
+		Defaults.reset(key)
+		cancellable.cancel()
+
+		waitForExpectations(timeout: 10)
+	}
 }


### PR DESCRIPTION
Support `removeDuplicates()` combine operator for  Defaults  publishers #43 

```swift
	Defaults
	   .publisher(key, options: [])
	   .removeDuplicates()
```


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#43: Add `removeDuplicates` option to `Defaults.publisher(keys...)` and `Defaults.publisherAll()`](https://issuehunt.io/repos/129132562/issues/43)
---
</details>
<!-- /Issuehunt content-->