### PR TITLE
Fix compiler complain that `NSSecureCodingKeyChange` is only available in iOS 11.0 or newer

### DIFF
--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -447,10 +447,10 @@ extension Defaults.ObservationOptions {
 	}
 }
 
-@available(macOS 10.13, macOSApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
+@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
 extension Defaults.NSSecureCodingKeyChange: Equatable where Value: Equatable { }
 
-@available(macOS 10.13, macOSApplicationExtension 10.13, watchOSApplicationExtension 4.0, *)
+@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, iOSApplicationExtension 11.0, macOSApplicationExtension 10.13, tvOSApplicationExtension 11.0, watchOSApplicationExtension 4.0, *)
 extension Defaults.NSSecureCodingOptionalKeyChange: Equatable where Value: Equatable { }
 
 extension Defaults.KeyChange: Equatable where Value: Equatable { }


### PR DESCRIPTION
## Summary

Fixes: #63.
Probably Fixes: #61

Add @available iOS 11.0 attribute at the constraint of the `NSSecureCodingKeyChange` and `NSSecureCodingOptionalKeyChange`.
