### PR TITLE
Fix crash in `.publisher()` caused by immediately cancelling subscriber

### DIFF
--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -27,7 +27,6 @@ extension Defaults {
 		}
 
 		func cancel() {
-			observation?.invalidate()
 			observation = nil
 			subscriber = nil
 		}

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -925,4 +925,20 @@ final class DefaultsTests: XCTestCase {
 
 		waitForExpectations(timeout: 10)
 	}
+
+	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
+	func testImmediatelyFinishingPublisherCombine() {
+		let key = Defaults.Key<Bool>("observeKey", default: false)
+		let expect = expectation(description: "Observation closure being called without crashing")
+
+		let cancellable = Defaults
+			.publisher(key, options: [.initial])
+			.first()
+			.sink { _ in
+				expect.fulfill()
+			}
+
+		cancellable.cancel()
+		waitForExpectations(timeout: 10)
+	}
 }


### PR DESCRIPTION
Fixes #65