### PR TITLE
Add `Defaults.AnySerializable`

### DIFF
--- a/Sources/Defaults/Defaults+AnySerializable.swift
+++ b/Sources/Defaults/Defaults+AnySerializable.swift
@@ -56,7 +56,7 @@ extension Optional: Defaults.AnySerializableProtocol where Wrapped: Defaults.Any
 	public init<Value: Defaults.Serializable>(_ value: Value) {
 		self = .some(Wrapped(value))
 	}
-	public func get<Value>() -> Value? where Value : DefaultsSerializable {
+	public func get<Value>() -> Value? where Value: DefaultsSerializable {
 		self?.get()
 	}
 	public func get<Value: Defaults.Serializable>(_: Value.Type) -> Value? {

--- a/Sources/Defaults/Defaults+AnySerializable.swift
+++ b/Sources/Defaults/Defaults+AnySerializable.swift
@@ -1,14 +1,7 @@
 import CoreGraphics
 import Foundation
 
-public protocol DefaultsAnySerializableProtocol: Defaults.Serializable {
-	init<Value: Defaults.Serializable>(_ value: Value)
-	func get<Value: Defaults.Serializable>() -> Value?
-	func get<Value: Defaults.Serializable>(_: Value.Type) -> Value?
-}
-
 extension Defaults {
-	public typealias AnySerializableProtocol = DefaultsAnySerializableProtocol
 	/**
 	Type-erased wrappers for `Defaults.Serializable` values.
 	It can be used when the user wants to create an `Any` value that conforms to `Defaults.Serializable`.
@@ -32,7 +25,7 @@ extension Defaults {
 	let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: [mime.JSON])
 	```
 	*/
-	public struct AnySerializable: AnySerializableProtocol {
+	public struct AnySerializable: Defaults.Serializable {
 		var value: Any
 		public static let bridge = AnyBridge()
 

--- a/Sources/Defaults/Defaults+AnySerializable.swift
+++ b/Sources/Defaults/Defaults+AnySerializable.swift
@@ -30,7 +30,7 @@ extension Defaults {
 	let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: [mime.JSON])
 	```
 	*/
-	public struct AnySerializable: DefaultsAnySerializableProtocol {
+	public struct AnySerializable: AnySerializableProtocol {
 		var value: Any
 		public static let bridge = AnyBridge()
 
@@ -38,15 +38,15 @@ extension Defaults {
 			self.value = value ?? ()
 		}
 
-		public init<Value: Defaults.Serializable>(_ value: Value) {
+		public init<Value: Serializable>(_ value: Value) {
 			self.value = Value.toSerializable(value) ?? ()
 		}
 
-		public func get<Value: Defaults.Serializable>() -> Value? { Value.toValue(value) }
+		public func get<Value: Serializable>() -> Value? { Value.toValue(value) }
 
-		public func get<Value: Defaults.Serializable>(_: Value.Type) -> Value? { Value.toValue(value) }
+		public func get<Value: Serializable>(_: Value.Type) -> Value? { Value.toValue(value) }
 
-		public mutating func set<Value: Defaults.Serializable>(_ newValue: Value) {
+		public mutating func set<Value: Serializable>(_ newValue: Value) {
 			value = Value.toSerializable(newValue) ?? ()
 		}
 	}
@@ -89,14 +89,14 @@ extension Defaults {
 	print(float) //=> 1_213.14
 	```
 	*/
-	public static subscript<T: Serializable, Value: Defaults.AnySerializableProtocol>(key: Key<Value>) -> T? {
+	public static subscript<T: Serializable, Value: AnySerializableProtocol>(key: Key<Value>) -> T? {
 		get { key.suite[key].get() }
 		set {
 			key.suite[key] = Value(newValue)
 		}
 	}
 
-	public static subscript<T: Serializable, Value: Defaults.AnySerializableProtocol>(key: Key<Value>, type type: T.Type) -> T? {
+	public static subscript<T: Serializable, Value: AnySerializableProtocol>(key: Key<Value>, type type: T.Type) -> T? {
 		get { key.suite[key].get(type) }
 		set {
 			key.suite[key] = Value(newValue)

--- a/Sources/Defaults/Defaults+AnySerializable.swift
+++ b/Sources/Defaults/Defaults+AnySerializable.swift
@@ -1,210 +1,257 @@
 import CoreGraphics
 import Foundation
 
+public protocol DefaultsAnySerializableProtocol: Defaults.Serializable {
+	init<Value: Defaults.Serializable>(_ value: Value)
+	func get<Value: Defaults.Serializable>() -> Value?
+	func get<Value: Defaults.Serializable>(_: Value.Type) -> Value?
+}
+
 extension Defaults {
-  /**
-  Have an internal property `value` which` should always be a UserDefaults native supported type.
+	public typealias AnySerializableProtocol = DefaultsAnySerializableProtocol
+	/**
+	Have an internal property `value` which` should always be a UserDefaults native supported type.
 
-  `get` will deserialize internal value to  the type user explicit in function parameter.
+	`get` will deserialize internal value to the type user explicit in function parameter.
 
-  ```
-  let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
-  print(Defaults[any].get(Int.self)) //=> 121_314
-  ```
+	```
+	let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
+	print(Defaults[any].get(Int.self)) //=> 121_314
+	```
 
-  `set`will serialize `Value` to UserDefaults native supported type and assign it to internal `value`.
+	- Note: the only way to assign non-serializable value is using `ExpressibleByArrayLiteral` or `ExpressibleByDictionaryLiteral` to assign a type which is not UserDefaults native supported type.
 
-  ```
-  let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
-  Defaults[any].set("🦄")
-  print(Defaults[any].get(String.self)) //=> 🦄
-  ```
+	```
+	private enum mime: String, Defaults.Serializable {
+		case JSON = "application/json"
+	}
 
-  - Note: the only way to assign non-serializable value is using `ExpressibleByArrayLiteral` or `ExpressibleByDictionaryLiteral` to assign a type which is not UserDefaults native supported type.
+	// Failed: Attempt to insert non-property list object
+	let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: [mime.JSON])
+	```
+	*/
+	public struct AnySerializable: DefaultsAnySerializableProtocol {
+		var value: Any
+		public static let bridge = AnyBridge()
 
-  ```
-  private enum mime: String, Defaults.Serializable {
-    case JSON = "application/json"
-  }
-  let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
+		init<T>(value: T?) {
+			self.value = value ?? ()
+		}
 
-  // Failed: Attempt to insert non-property list object
-  Defaults[any] = [mime.JSON]
+		public init<Value: Defaults.Serializable>(_ value: Value) {
+			self.value = Value.toSerializable(value) ?? ()
+		}
 
-  // Success
-  Defaults[any].set(value: [mime.JSON])
-  ```
-  */
-  public struct AnySerializable: Defaults.Serializable {
-    var value: Any
-    public static let bridge = AnyBridge()
+		public func get<Value: Defaults.Serializable>() -> Value? { Value.toValue(value) }
 
-    init<T>(value: T?) {
-      self.value = value ?? ()
-    }
+		public func get<Value: Defaults.Serializable>(_: Value.Type) -> Value? { Value.toValue(value) }
 
-    public init<Value: Defaults.Serializable>(_ value: Value) {
-      self.value = Value.toSerializable(value) ?? ()
-    }
+		public mutating func set<Value: Defaults.Serializable>(_ newValue: Value) {
+			value = Value.toSerializable(newValue) ?? ()
+		}
+	}
+}
 
-    public func get<Value: Defaults.Serializable>(_: Value.Type) -> Value? {
-      Value.toValue(self.value)
-    }
+extension Optional: Defaults.AnySerializableProtocol where Wrapped: Defaults.AnySerializableProtocol {
+	public init<Value: Defaults.Serializable>(_ value: Value) {
+		self = .some(Wrapped(value))
+	}
+	public func get<Value>() -> Value? where Value : DefaultsSerializable {
+		self?.get()
+	}
+	public func get<Value: Defaults.Serializable>(_: Value.Type) -> Value? {
+		self?.get(Value.self)
+	}
+}
 
-    public mutating func set<Value: Defaults.Serializable>(value: Value) {
-      self.value = Value.toSerializable(value) ?? ()
-    }
-  }
+extension Defaults {
+	/**
+	Here are the subscription for `Defaults.Key<Defaults.AnySerializable>`.
+
+	By default, `Defaults[any]` will return `Defaults.AnySerializable`.
+	With these subscription we can get the internal `value` with `Defaults[any]`.
+
+	```
+	let any = Defaults.Key<Defaults.AnySerializable>("anyKey", default: 121_314)
+	let int: Int = Defaults[any]
+	print(int) //=> 121_314
+	Defaults[any] = "🦄"
+	let string: String = Defaults[any]
+	print(string) //=> 🦄
+	```
+
+	For more ambiguous cases,  we also provide second parameter `type` to specify the type of `value`
+
+	```
+	let any = Defaults.Key<Defaults.AnySerializable>("anyKey", default: 121_314)
+	Defaults[any, type: Float.self] = 1_213.14
+	let float = Defaults[any, type: Float.self]
+	print(float) //=> 1_213.14
+	```
+	*/
+	public static subscript<T: Serializable, Value: Defaults.AnySerializableProtocol>(key: Key<Value>) -> T? {
+		get { key.suite[key].get() }
+		set {
+			key.suite[key] = Value(newValue)
+		}
+	}
+
+	public static subscript<T: Serializable, Value: Defaults.AnySerializableProtocol>(key: Key<Value>, type type: T.Type) -> T? {
+		get { key.suite[key].get(type) }
+		set {
+			key.suite[key] = Value(newValue)
+		}
+	}
 }
 
 extension Defaults.AnySerializable: Hashable {
-  public func hash(into hasher: inout Hasher) {
-    switch value {
-    case let value as Data:
-      return hasher.combine(value)
-    case let value as Date:
-      return hasher.combine(value)
-    case let value as Bool:
-      return hasher.combine(value)
-    case let value as UInt8:
-      return hasher.combine(value)
-    case let value as Int8:
-      return hasher.combine(value)
-    case let value as UInt16:
-      return hasher.combine(value)
-    case let value as Int16:
-      return hasher.combine(value)
-    case let value as UInt32:
-      return hasher.combine(value)
-    case let value as Int32:
-      return hasher.combine(value)
-    case let value as UInt64:
-      return hasher.combine(value)
-    case let value as Int64:
-      return hasher.combine(value)
-    case let value as UInt:
-      return hasher.combine(value)
-    case let value as Int:
-      return hasher.combine(value)
-    case let value as Float:
-      return hasher.combine(value)
-    case let value as Double:
-      return hasher.combine(value)
-    case let value as CGFloat:
-      return hasher.combine(value)
-    case let value as String:
-      return hasher.combine(value)
-    case let value as [AnyHashable: AnyHashable]:
-      return hasher.combine(value)
-    case let value as [AnyHashable]:
-      return hasher.combine(value)
-    default:
-      break
-    }
-  }
+	public func hash(into hasher: inout Hasher) {
+		switch self.value {
+		case let value as Data:
+			return hasher.combine(value)
+		case let value as Date:
+			return hasher.combine(value)
+		case let value as Bool:
+			return hasher.combine(value)
+		case let value as UInt8:
+			return hasher.combine(value)
+		case let value as Int8:
+			return hasher.combine(value)
+		case let value as UInt16:
+			return hasher.combine(value)
+		case let value as Int16:
+			return hasher.combine(value)
+		case let value as UInt32:
+			return hasher.combine(value)
+		case let value as Int32:
+			return hasher.combine(value)
+		case let value as UInt64:
+			return hasher.combine(value)
+		case let value as Int64:
+			return hasher.combine(value)
+		case let value as UInt:
+			return hasher.combine(value)
+		case let value as Int:
+			return hasher.combine(value)
+		case let value as Float:
+			return hasher.combine(value)
+		case let value as Double:
+			return hasher.combine(value)
+		case let value as CGFloat:
+			return hasher.combine(value)
+		case let value as String:
+			return hasher.combine(value)
+		case let value as [AnyHashable: AnyHashable]:
+			return hasher.combine(value)
+		case let value as [AnyHashable]:
+			return hasher.combine(value)
+		default:
+			break
+		}
+	}
 }
 
 extension Defaults.AnySerializable: Equatable {
-  public static func == (lhs: Defaults.AnySerializable, rhs: Defaults.AnySerializable) -> Bool {
-    switch (lhs.value, rhs.value) {
-    case let (lhs as Data, rhs as Data):
-      return lhs == rhs
-    case let (lhs as Date, rhs as Date):
-      return lhs == rhs
-    case let (lhs as Bool, rhs as Bool):
-      return lhs == rhs
-    case let (lhs as UInt8, rhs as UInt8):
-      return lhs == rhs
-    case let (lhs as Int8, rhs as Int8):
-      return lhs == rhs
-    case let (lhs as UInt16, rhs as UInt16):
-      return lhs == rhs
-    case let (lhs as Int16, rhs as Int16):
-      return lhs == rhs
-    case let (lhs as UInt32, rhs as UInt32):
-      return lhs == rhs
-    case let (lhs as Int32, rhs as Int32):
-      return lhs == rhs
-    case let (lhs as UInt64, rhs as UInt64):
-      return lhs == rhs
-    case let (lhs as Int64, rhs as Int64):
-      return lhs == rhs
-    case let (lhs as UInt, rhs as UInt):
-      return lhs == rhs
-    case let (lhs as Int, rhs as Int):
-      return lhs == rhs
-    case let (lhs as Float, rhs as Float):
-      return lhs == rhs
-    case let (lhs as Double, rhs as Double):
-      return lhs == rhs
-    case let (lhs as CGFloat, rhs as CGFloat):
-      return lhs == rhs
-    case let (lhs as String, rhs as String):
-      return lhs == rhs
-    case let (lhs as [AnyHashable: Any], rhs as [AnyHashable: Any]):
-      return lhs.toDictionary() == rhs.toDictionary()
-    case let (lhs as [Any], rhs as [Any]):
-      return lhs.toSequence() == rhs.toSequence()
-    default:
-      return false
-    }
-  }
+	public static func == (lhs: Defaults.AnySerializable, rhs: Defaults.AnySerializable) -> Bool {
+		switch (lhs.value, rhs.value) {
+		case let (lhs as Data, rhs as Data):
+			return lhs == rhs
+		case let (lhs as Date, rhs as Date):
+			return lhs == rhs
+		case let (lhs as Bool, rhs as Bool):
+			return lhs == rhs
+		case let (lhs as UInt8, rhs as UInt8):
+			return lhs == rhs
+		case let (lhs as Int8, rhs as Int8):
+			return lhs == rhs
+		case let (lhs as UInt16, rhs as UInt16):
+			return lhs == rhs
+		case let (lhs as Int16, rhs as Int16):
+			return lhs == rhs
+		case let (lhs as UInt32, rhs as UInt32):
+			return lhs == rhs
+		case let (lhs as Int32, rhs as Int32):
+			return lhs == rhs
+		case let (lhs as UInt64, rhs as UInt64):
+			return lhs == rhs
+		case let (lhs as Int64, rhs as Int64):
+			return lhs == rhs
+		case let (lhs as UInt, rhs as UInt):
+			return lhs == rhs
+		case let (lhs as Int, rhs as Int):
+			return lhs == rhs
+		case let (lhs as Float, rhs as Float):
+			return lhs == rhs
+		case let (lhs as Double, rhs as Double):
+			return lhs == rhs
+		case let (lhs as CGFloat, rhs as CGFloat):
+			return lhs == rhs
+		case let (lhs as String, rhs as String):
+			return lhs == rhs
+		case let (lhs as [AnyHashable: Any], rhs as [AnyHashable: Any]):
+			return lhs.toDictionary() == rhs.toDictionary()
+		case let (lhs as [Any], rhs as [Any]):
+			return lhs.toSequence() == rhs.toSequence()
+		default:
+			return false
+		}
+	}
 }
 
 extension Defaults.AnySerializable: ExpressibleByStringLiteral {
-  public init(stringLiteral value: String) {
-    self.init(value: value)
-  }
+	public init(stringLiteral value: String) {
+		self.init(value: value)
+	}
 }
 
 extension Defaults.AnySerializable: ExpressibleByNilLiteral {
-  public init(nilLiteral _: ()) {
-    self.init(value: nil as Any?)
-  }
+	public init(nilLiteral _: ()) {
+		self.init(value: nil as Any?)
+	}
 }
 
 extension Defaults.AnySerializable: ExpressibleByBooleanLiteral {
-  public init(booleanLiteral value: Bool) {
-    self.init(value: value)
-  }
+	public init(booleanLiteral value: Bool) {
+		self.init(value: value)
+	}
 }
 
 extension Defaults.AnySerializable: ExpressibleByIntegerLiteral {
-  public init(integerLiteral value: Int) {
-    self.init(value: value)
-  }
+	public init(integerLiteral value: Int) {
+		self.init(value: value)
+	}
 }
 
 extension Defaults.AnySerializable: ExpressibleByFloatLiteral {
-  public init(floatLiteral value: Double) {
-    self.init(value: value)
-  }
+	public init(floatLiteral value: Double) {
+		self.init(value: value)
+	}
 }
 
 extension Defaults.AnySerializable: ExpressibleByArrayLiteral {
-  public init(arrayLiteral elements: Any...) {
-    self.init(value: elements)
-  }
+	public init(arrayLiteral elements: Any...) {
+		self.init(value: elements)
+	}
 }
 
 extension Defaults.AnySerializable: ExpressibleByDictionaryLiteral {
-  public init(dictionaryLiteral elements: (AnyHashable, Any)...) {
-    self.init(value: [AnyHashable: Any](uniqueKeysWithValues: elements))
-  }
+	public init(dictionaryLiteral elements: (AnyHashable, Any)...) {
+		self.init(value: [AnyHashable: Any](uniqueKeysWithValues: elements))
+	}
 }
 
 extension Defaults.AnySerializable: _DefaultsOptionalType {
-  public var isNil: Bool { value is Void }
+	public var isNil: Bool { value is Void }
 }
 
 extension Sequence {
-  fileprivate func toSequence() -> [Defaults.AnySerializable] {
-    map { Defaults.AnySerializable(value: $0) }
-  }
+	fileprivate func toSequence() -> [Defaults.AnySerializable] {
+		map { Defaults.AnySerializable(value: $0) }
+	}
 }
 
 extension Dictionary {
-  fileprivate func toDictionary() -> [AnyHashable: Defaults.AnySerializable] {
-    reduce(into: [AnyHashable: Defaults.AnySerializable]()) { memo, tuple in memo[tuple.key] = Defaults.AnySerializable(value: tuple.value) }
-  }
+	fileprivate func toDictionary() -> [AnyHashable: Defaults.AnySerializable] {
+		reduce(into: [AnyHashable: Defaults.AnySerializable]()) { memo, tuple in memo[tuple.key] = Defaults.AnySerializable(value: tuple.value) }
+	}
 }

--- a/Sources/Defaults/Defaults+AnySerializable.swift
+++ b/Sources/Defaults/Defaults+AnySerializable.swift
@@ -1,0 +1,210 @@
+import CoreGraphics
+import Foundation
+
+extension Defaults {
+  /**
+  Have an internal property `value` which` should always be a UserDefaults native supported type.
+
+  `get` will deserialize internal value to  the type user explicit in function parameter.
+
+  ```
+  let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
+  print(Defaults[any].get(Int.self)) //=> 121_314
+  ```
+
+  `set`will serialize `Value` to UserDefaults native supported type and assign it to internal `value`.
+
+  ```
+  let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
+  Defaults[any].set("🦄")
+  print(Defaults[any].get(String.self)) //=> 🦄
+  ```
+
+  - Note: the only way to assign non-serializable value is using `ExpressibleByArrayLiteral` or `ExpressibleByDictionaryLiteral` to assign a type which is not UserDefaults native supported type.
+
+  ```
+  private enum mime: String, Defaults.Serializable {
+    case JSON = "application/json"
+  }
+  let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
+
+  // Failed: Attempt to insert non-property list object
+  Defaults[any] = [mime.JSON]
+
+  // Success
+  Defaults[any].set(value: [mime.JSON])
+  ```
+  */
+  public struct AnySerializable: Defaults.Serializable {
+    var value: Any
+    public static let bridge = AnyBridge()
+
+    init<T>(value: T?) {
+      self.value = value ?? ()
+    }
+
+    public init<Value: Defaults.Serializable>(_ value: Value) {
+      self.value = Value.toSerializable(value) ?? ()
+    }
+
+    public func get<Value: Defaults.Serializable>(_: Value.Type) -> Value? {
+      Value.toValue(self.value)
+    }
+
+    public mutating func set<Value: Defaults.Serializable>(value: Value) {
+      self.value = Value.toSerializable(value) ?? ()
+    }
+  }
+}
+
+extension Defaults.AnySerializable: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    switch value {
+    case let value as Data:
+      return hasher.combine(value)
+    case let value as Date:
+      return hasher.combine(value)
+    case let value as Bool:
+      return hasher.combine(value)
+    case let value as UInt8:
+      return hasher.combine(value)
+    case let value as Int8:
+      return hasher.combine(value)
+    case let value as UInt16:
+      return hasher.combine(value)
+    case let value as Int16:
+      return hasher.combine(value)
+    case let value as UInt32:
+      return hasher.combine(value)
+    case let value as Int32:
+      return hasher.combine(value)
+    case let value as UInt64:
+      return hasher.combine(value)
+    case let value as Int64:
+      return hasher.combine(value)
+    case let value as UInt:
+      return hasher.combine(value)
+    case let value as Int:
+      return hasher.combine(value)
+    case let value as Float:
+      return hasher.combine(value)
+    case let value as Double:
+      return hasher.combine(value)
+    case let value as CGFloat:
+      return hasher.combine(value)
+    case let value as String:
+      return hasher.combine(value)
+    case let value as [AnyHashable: AnyHashable]:
+      return hasher.combine(value)
+    case let value as [AnyHashable]:
+      return hasher.combine(value)
+    default:
+      break
+    }
+  }
+}
+
+extension Defaults.AnySerializable: Equatable {
+  public static func == (lhs: Defaults.AnySerializable, rhs: Defaults.AnySerializable) -> Bool {
+    switch (lhs.value, rhs.value) {
+    case let (lhs as Data, rhs as Data):
+      return lhs == rhs
+    case let (lhs as Date, rhs as Date):
+      return lhs == rhs
+    case let (lhs as Bool, rhs as Bool):
+      return lhs == rhs
+    case let (lhs as UInt8, rhs as UInt8):
+      return lhs == rhs
+    case let (lhs as Int8, rhs as Int8):
+      return lhs == rhs
+    case let (lhs as UInt16, rhs as UInt16):
+      return lhs == rhs
+    case let (lhs as Int16, rhs as Int16):
+      return lhs == rhs
+    case let (lhs as UInt32, rhs as UInt32):
+      return lhs == rhs
+    case let (lhs as Int32, rhs as Int32):
+      return lhs == rhs
+    case let (lhs as UInt64, rhs as UInt64):
+      return lhs == rhs
+    case let (lhs as Int64, rhs as Int64):
+      return lhs == rhs
+    case let (lhs as UInt, rhs as UInt):
+      return lhs == rhs
+    case let (lhs as Int, rhs as Int):
+      return lhs == rhs
+    case let (lhs as Float, rhs as Float):
+      return lhs == rhs
+    case let (lhs as Double, rhs as Double):
+      return lhs == rhs
+    case let (lhs as CGFloat, rhs as CGFloat):
+      return lhs == rhs
+    case let (lhs as String, rhs as String):
+      return lhs == rhs
+    case let (lhs as [AnyHashable: Any], rhs as [AnyHashable: Any]):
+      return lhs.toDictionary() == rhs.toDictionary()
+    case let (lhs as [Any], rhs as [Any]):
+      return lhs.toSequence() == rhs.toSequence()
+    default:
+      return false
+    }
+  }
+}
+
+extension Defaults.AnySerializable: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(value: value)
+  }
+}
+
+extension Defaults.AnySerializable: ExpressibleByNilLiteral {
+  public init(nilLiteral _: ()) {
+    self.init(value: nil as Any?)
+  }
+}
+
+extension Defaults.AnySerializable: ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Bool) {
+    self.init(value: value)
+  }
+}
+
+extension Defaults.AnySerializable: ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Int) {
+    self.init(value: value)
+  }
+}
+
+extension Defaults.AnySerializable: ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Double) {
+    self.init(value: value)
+  }
+}
+
+extension Defaults.AnySerializable: ExpressibleByArrayLiteral {
+  public init(arrayLiteral elements: Any...) {
+    self.init(value: elements)
+  }
+}
+
+extension Defaults.AnySerializable: ExpressibleByDictionaryLiteral {
+  public init(dictionaryLiteral elements: (AnyHashable, Any)...) {
+    self.init(value: [AnyHashable: Any](uniqueKeysWithValues: elements))
+  }
+}
+
+extension Defaults.AnySerializable: _DefaultsOptionalType {
+  public var isNil: Bool { value is Void }
+}
+
+extension Sequence {
+  fileprivate func toSequence() -> [Defaults.AnySerializable] {
+    map { Defaults.AnySerializable(value: $0) }
+  }
+}
+
+extension Dictionary {
+  fileprivate func toDictionary() -> [AnyHashable: Defaults.AnySerializable] {
+    reduce(into: [AnyHashable: Defaults.AnySerializable]()) { memo, tuple in memo[tuple.key] = Defaults.AnySerializable(value: tuple.value) }
+  }
+}

--- a/Sources/Defaults/Defaults+AnySerializable.swift
+++ b/Sources/Defaults/Defaults+AnySerializable.swift
@@ -12,16 +12,16 @@ extension Defaults {
 	/**
 	Type-erased wrappers for `Defaults.Serializable` values.
 	It can be used when the user wants to create an `Any` value that conforms to `Defaults.Serializable`.
-	It will have an internal property `value` which` should always be a UserDefaults native supported type.
+	It will have an internal property `value` which` should always be a UserDefaults natively supported type.
 
-	`get` will deserialize internal value to the type user explicit in the function parameter.
+	`get` will deserialize internal value to the type that user explicit in the function parameter.
 
 	```
 	let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
 	print(Defaults[any].get(Int.self)) //=> 121_314
 	```
 
-	- Note: the only way to assign a non-serializable value is using `ExpressibleByArrayLiteral` or `ExpressibleByDictionaryLiteral` to assign a type which is not UserDefaults native supported type.
+	- Note: the only way to assign a non-serializable value is using `ExpressibleByArrayLiteral` or `ExpressibleByDictionaryLiteral` to assign a type that is not UserDefaults natively supported type.
 
 	```
 	private enum mime: String, Defaults.Serializable {

--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -305,7 +305,7 @@ extension Defaults {
 
 		public func deserialize(_ object: Serializable?) -> Value? {
 			Value(value: object)
-    }
+		}
 
 		public func serialize(_ value: Value?) -> Serializable? {
 			value?.value

--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -299,16 +299,16 @@ extension Defaults {
 }
 
 extension Defaults {
-  public struct AnyBridge: Defaults.Bridge {
-    public typealias Value = Defaults.AnySerializable
-    public typealias Serializable = Any
+	public struct AnyBridge: Defaults.Bridge {
+		public typealias Value = Defaults.AnySerializable
+		public typealias Serializable = Any
 
-    public func deserialize(_ object: Serializable?) -> Value? {
-      Value(value: object)
+		public func deserialize(_ object: Serializable?) -> Value? {
+			Value(value: object)
     }
 
-    public func serialize(_ value: Value?) -> Serializable? {
-      value?.value
-    }
-  }
+		public func serialize(_ value: Value?) -> Serializable? {
+			value?.value
+		}
+	}
 }

--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -297,3 +297,18 @@ extension Defaults {
 		}
 	}
 }
+
+extension Defaults {
+  public struct AnyBridge: Defaults.Bridge {
+    public typealias Value = Defaults.AnySerializable
+    public typealias Serializable = Any
+
+    public func deserialize(_ object: Serializable?) -> Value? {
+      Value(value: object)
+    }
+
+    public func serialize(_ value: Value?) -> Serializable? {
+      value?.value
+    }
+  }
+}

--- a/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
+++ b/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
@@ -77,13 +77,14 @@ final class DefaultsAnySerializableTests: XCTestCase {
 		if let mimeType: mime = Defaults[.magic]["enum"]?.get() {
 			XCTAssertEqual(mimeType, mime.STREAM)
 		}
-		let anyArray = Defaults.Key<[Defaults.AnySerializable]>("anyArrayKey", default: [Defaults.AnySerializable(mime.JSON)])
-
-		if let mimeType: mime = Defaults[anyArray][0].get() {
-			XCTAssertEqual(mimeType, mime.JSON) //=> "application/json"
+		Defaults[any].set(mime.JSON)
+		if let mimeType: mime = Defaults[any].get() {
+			XCTAssertEqual(mime.JSON, mimeType)
 		}
-		Defaults[anyArray].append(123)
-		XCTAssertEqual(Defaults[anyArray][1].get(Int.self), 123)
+		Defaults[any].set(mime.STREAM)
+		if let mimeType: mime = Defaults[any].get() {
+			XCTAssertEqual(mime.STREAM, mimeType)
+		}
 	}
 
 	func testKey() {

--- a/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
+++ b/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
@@ -66,7 +66,9 @@ final class DefaultsAnySerializableTests: XCTestCase {
 		Defaults[.magic]["enum"] = Defaults.AnySerializable(mime.JSON)
 		XCTAssertEqual(Defaults[.magic]["unicorn"], "🦄")
 		XCTAssertEqual(Defaults[.magic]["number"], 3)
-		XCTAssertEqual(Defaults[.magic]["boolean"], true)
+		if let bool: Bool = Defaults[.magic]["unicorn"]?.get() {
+			XCTAssertTrue(bool)
+		}
 		XCTAssertEqual(Defaults[.magic]["enum"]?.get(), mime.JSON)
 		Defaults[.magic]["enum"]?.set(mime.STREAM)
 		if let value: String = Defaults[.magic]["unicorn"]?.get() {
@@ -242,7 +244,7 @@ final class DefaultsAnySerializableTests: XCTestCase {
 		Defaults[key].insert(bool)
 		XCTAssertTrue(Defaults[key].contains(bool))
 
-		let float = Defaults.AnySerializable(Float(1_213.14))
+		let float = Defaults.AnySerializable(Float(1213.14))
 		Defaults[key].insert(float)
 		XCTAssertTrue(Defaults[key].contains(float))
 
@@ -295,7 +297,9 @@ final class DefaultsAnySerializableTests: XCTestCase {
 		Defaults[key]["number"] = 3
 		Defaults[key]["boolean"] = true
 		XCTAssertEqual(Defaults[key]["number"], 3)
-		XCTAssertEqual(Defaults[key]["boolean"], true)
+		if let bool: Bool = Defaults[.magic]["unicorn"]?.get() {
+			XCTAssertTrue(bool)
+		}
 		Defaults[key]["set"] = Defaults.AnySerializable(Set([1]))
 		XCTAssertEqual(Defaults[key]["set"]!.get(Set<Int>.self)!.first, 1)
 		Defaults[key]["nil"] = nil

--- a/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
+++ b/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
@@ -1,0 +1,443 @@
+import Defaults
+import Foundation
+import XCTest
+
+private enum mime: String, Defaults.Serializable {
+  case JSON = "application/json"
+}
+
+private struct CodableUnicorn: Defaults.Serializable, Codable {
+  let is_missing: Bool
+}
+
+private struct Unicorn: Defaults.Serializable, Hashable {
+  static let bridge = UnicornBridge()
+  let is_missing: Bool
+}
+
+private struct UnicornBridge: Defaults.Bridge {
+  typealias Value = Unicorn
+  typealias Serializable = Bool
+
+  func serialize(_ value: Value?) -> Serializable? {
+    value?.is_missing
+  }
+
+  func deserialize(_ object: Serializable?) -> Value? {
+    return Value(is_missing: object!)
+  }
+}
+
+extension Defaults.Keys {
+  fileprivate static let magic = Key<[String: Defaults.AnySerializable]>("magic", default: [:])
+  fileprivate static let anyKey = Key<Defaults.AnySerializable>("anyKey", default: "🦄")
+  fileprivate static let anyArrayKey = Key<[Defaults.AnySerializable]>("anyArrayKey", default: ["No.1 🦄", "No.2 🦄"])
+  fileprivate static let anyDictionaryKey = Key<[String: Defaults.AnySerializable]>("anyDictionaryKey", default: ["unicorn": "🦄"])
+}
+
+final class DefaultsAnySerializableTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    Defaults.removeAll()
+  }
+
+  override func tearDown() {
+    super.tearDown()
+    Defaults.removeAll()
+  }
+
+  func testReadMeExample() {
+    Defaults[.magic]["unicorn"] = "🦄"
+    Defaults[.magic]["number"] = 3
+    Defaults[.magic]["boolean"] = true
+    Defaults[.magic]["enum"] = Defaults.AnySerializable(mime.JSON)
+    XCTAssertEqual(Defaults[.magic]["unicorn"]?.get(String.self), "🦄")
+    XCTAssertEqual(Defaults[.magic]["number"]?.get(Int.self) , 3)
+    XCTAssertEqual(Defaults[.magic]["boolean"]?.get(Bool.self) , true)
+    XCTAssertEqual(Defaults[.magic]["enum"]?.get(mime.self) , mime.JSON)
+  }
+
+  func testKey() {
+    // Test Int
+    let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
+    XCTAssertEqual(Defaults[any].get(Int.self) , 121_314)
+    // Test Int8
+    let int8 = Int8.max
+    Defaults[any] = Defaults.AnySerializable(int8)
+    XCTAssertEqual(Defaults[any].get(Int8.self), int8)
+    // Test Int16
+    let int16 = Int16.max
+    Defaults[any] = Defaults.AnySerializable(int16)
+    XCTAssertEqual(Defaults[any].get(Int16.self), int16)
+    // Test Int32
+    let int32 = Int32.max
+    Defaults[any] = Defaults.AnySerializable(int32)
+    XCTAssertEqual(Defaults[any].get(Int32.self), int32)
+    // Test Int64
+    let int64 = Int64.max
+    Defaults[any] = Defaults.AnySerializable(int64)
+    XCTAssertEqual(Defaults[any].get(Int64.self), int64)
+    // Test UInt
+    let uint = UInt.max
+    Defaults[any] = Defaults.AnySerializable(uint)
+    XCTAssertEqual(Defaults[any].get(UInt.self), uint)
+    // Test UInt8
+    let uint8 = UInt8.max
+    Defaults[any] = Defaults.AnySerializable(uint8)
+    XCTAssertEqual(Defaults[any].get(UInt8.self), uint8)
+    // Test UInt16
+    let uint16 = UInt16.max
+    Defaults[any] = Defaults.AnySerializable(uint16)
+    XCTAssertEqual(Defaults[any].get(UInt16.self), uint16)
+    // Test UInt32
+    let uint32 = UInt32.max
+    Defaults[any] = Defaults.AnySerializable(uint32)
+    XCTAssertEqual(Defaults[any].get(UInt32.self), uint32)
+    // Test UInt64
+    let uint64 = UInt64.max
+    Defaults[any] = Defaults.AnySerializable(uint64)
+    XCTAssertEqual(Defaults[any].get(UInt64.self), uint64)
+    // Test Double
+    Defaults[any] = 12_131.4
+    XCTAssertEqual(Defaults[any].get(Double.self), 12_131.4)
+    // Test Bool
+    Defaults[any] = true
+    XCTAssertTrue(Defaults[any].get(Bool.self)!)
+    // Test String
+    Defaults[any] = "121314"
+    XCTAssertEqual(Defaults[any].get(String.self), "121314")
+    // Test Float
+    let float: Float = 12_131.4
+    Defaults[any] = Defaults.AnySerializable(float)
+    XCTAssertEqual(Defaults[any].get(Float.self), float)
+    // Test Date
+    let date = Date()
+    Defaults[any] = Defaults.AnySerializable(date)
+    XCTAssertEqual(Defaults[any].get(Date.self), date)
+    // Test Data
+    let data = "121314".data(using: .utf8)
+    Defaults[any] = Defaults.AnySerializable(data)
+    XCTAssertEqual(Defaults[any].get(Data.self), data)
+    // Test Array
+    Defaults[any] = [1, 2, 3]
+    if let array = Defaults[any].get([Int].self) {
+      XCTAssertEqual(array[0], 1)
+      XCTAssertEqual(array[1], 2)
+      XCTAssertEqual(array[2], 3)
+    }
+    // Test Dictionary
+    Defaults[any] = ["unicorn": "🦄", "boolean": true, "number": 3]
+    if let dictionary = Defaults[any].get([String: Defaults.AnySerializable].self) {
+      XCTAssertEqual(dictionary["unicorn"]?.get(String.self), "🦄")
+      XCTAssertTrue(dictionary["boolean"]!.get(Bool.self)!)
+      XCTAssertEqual(dictionary["number"]?.get(Int.self), 3)
+    }
+    // Test Set
+    Defaults[any].set(value: Set([1]))
+    XCTAssertEqual(Defaults[any].get(Set<Int>.self)?.first, 1)
+    // Test URL
+    Defaults[any].set(value: URL(string: "https://example.com")!)
+    XCTAssertEqual(Defaults[any].get(URL.self)!, URL(string: "https://example.com")!)
+    #if os(macOS)
+    // Test NSColor
+    Defaults[any].set(value: NSColor(red: CGFloat(103) / CGFloat(0xFF), green: CGFloat(132) / CGFloat(0xFF), blue: CGFloat(255) / CGFloat(0xFF), alpha: 0.987))
+    XCTAssertEqual(Defaults[any].get(NSColor.self)!.alphaComponent, 0.987)
+    #else
+    // Test UIColor
+    Defaults[any] = Defaults.AnySerializable(UIColor(red: CGFloat(103) / CGFloat(0xFF), green: CGFloat(132) / CGFloat(0xFF), blue: CGFloat(255) / CGFloat(0xFF), alpha: 0.654))
+    XCTAssertEqual( Defaults[any].get(UIColor.self)?.cgColor.alpha, 0.654)
+    #endif
+    // Test Codable type
+    Defaults[any].set(value: CodableUnicorn(is_missing: false))
+    XCTAssertFalse(Defaults[any].get(CodableUnicorn.self)!.is_missing)
+    // Test Custom type
+    Defaults[any].set(value: Unicorn(is_missing: true))
+    XCTAssertTrue(Defaults[any].get(Unicorn.self)!.is_missing)
+    // Test nil
+    Defaults[any] = nil
+    XCTAssertEqual(Defaults[any], 121_314)
+  }
+
+  func testOptionalKey() {
+    let key = Defaults.Key<Defaults.AnySerializable?>("independentOptionalAnyKey")
+    XCTAssertNil(Defaults[key])
+    Defaults[key] = 12_131.4
+    XCTAssertEqual(Defaults[key]!.get(Double.self), 12_131.4)
+    Defaults[key] = nil
+    XCTAssertNil(Defaults[key])
+  }
+
+  func testArrayKey() {
+    let key = Defaults.Key<[Defaults.AnySerializable]>("independentArrayAnyKey", default: [123, 456])
+    XCTAssertEqual(Defaults[key][0].get(Int.self), 123)
+    XCTAssertEqual(Defaults[key][1].get(Int.self), 456)
+    Defaults[key][0] = 12_131.4
+    XCTAssertEqual(Defaults[key][0].get(Double.self), 12_131.4)
+  }
+
+  func testSetKey() {
+    let key = Defaults.Key<Set<Defaults.AnySerializable>>("independentArrayAnyKey", default: [123])
+    XCTAssertEqual(Defaults[key].first?.get(Int.self), 123)
+    Defaults[key].insert(12_131.4)
+    XCTAssertTrue(Defaults[key].contains(12_131.4))
+    let date = Defaults.AnySerializable(Date())
+    Defaults[key].insert(date)
+    XCTAssertTrue(Defaults[key].contains(date))
+    let data = Defaults.AnySerializable("Hello World!".data(using: .utf8))
+    Defaults[key].insert(data)
+    XCTAssertTrue(Defaults[key].contains(data))
+    let int = Defaults.AnySerializable(Int.max)
+    Defaults[key].insert(int)
+    XCTAssertTrue(Defaults[key].contains(int))
+    let int8 = Defaults.AnySerializable(Int8.max)
+    Defaults[key].insert(int8)
+    XCTAssertTrue(Defaults[key].contains(int8))
+    let int16 = Defaults.AnySerializable(Int16.max)
+    Defaults[key].insert(int16)
+    XCTAssertTrue(Defaults[key].contains(int16))
+    let int32 = Defaults.AnySerializable(Int32.max)
+    Defaults[key].insert(int32)
+    XCTAssertTrue(Defaults[key].contains(int32))
+    let int64 = Defaults.AnySerializable(Int64.max)
+    Defaults[key].insert(int64)
+    XCTAssertTrue(Defaults[key].contains(int64))
+    let uint = Defaults.AnySerializable(UInt.max)
+    Defaults[key].insert(uint)
+    XCTAssertTrue(Defaults[key].contains(uint))
+    let uint8 = Defaults.AnySerializable(UInt8.max)
+    Defaults[key].insert(uint8)
+    XCTAssertTrue(Defaults[key].contains(uint8))
+    let uint16 = Defaults.AnySerializable(UInt16.max)
+    Defaults[key].insert(uint16)
+    XCTAssertTrue(Defaults[key].contains(uint16))
+    let uint32 = Defaults.AnySerializable(UInt32.max)
+    Defaults[key].insert(uint32)
+    XCTAssertTrue(Defaults[key].contains(uint32))
+    let uint64 = Defaults.AnySerializable(UInt64.max)
+    Defaults[key].insert(uint64)
+    XCTAssertTrue(Defaults[key].contains(uint64))
+
+    let bool: Defaults.AnySerializable = false
+    Defaults[key].insert(bool)
+    XCTAssertTrue(Defaults[key].contains(bool))
+
+    let float = Defaults.AnySerializable(Float(1_213.14))
+    Defaults[key].insert(float)
+    XCTAssertTrue(Defaults[key].contains(float))
+
+    let cgFloat = Defaults.AnySerializable(CGFloat(12_131.415))
+    Defaults[key].insert(cgFloat)
+    XCTAssertTrue(Defaults[key].contains(cgFloat))
+
+    let string = Defaults.AnySerializable("Hello World!")
+    Defaults[key].insert(string)
+    XCTAssertTrue(Defaults[key].contains(string))
+
+    let array: Defaults.AnySerializable = [1, 2, 3, 4]
+    Defaults[key].insert(array)
+    XCTAssertTrue(Defaults[key].contains(array))
+
+    let dictionary: Defaults.AnySerializable = ["Hello": "World!"]
+    Defaults[key].insert(dictionary)
+    XCTAssertTrue(Defaults[key].contains(dictionary))
+
+    let unicorn = Defaults.AnySerializable(Unicorn(is_missing: true))
+    Defaults[key].insert(unicorn)
+    XCTAssertTrue(Defaults[key].contains(unicorn))
+  }
+
+  func testArrayOptionalKey() {
+    let key = Defaults.Key<[Defaults.AnySerializable]?>("testArrayOptionalAnyKey")
+    XCTAssertNil(Defaults[key])
+    Defaults[key] = [123]
+    Defaults[key]?.append(456)
+    XCTAssertEqual(Defaults[key]![0].get(Int.self), 123)
+    XCTAssertEqual(Defaults[key]![1].get(Int.self), 456)
+    Defaults[key]![0] = 12_131.4
+    XCTAssertEqual(Defaults[key]![0].get(Double.self), 12_131.4)
+  }
+
+  func testNestedArrayKey() {
+    let key = Defaults.Key<[[Defaults.AnySerializable]]>("testNestedArrayAnyKey", default: [[123]])
+    Defaults[key][0].append(456)
+    XCTAssertEqual(Defaults[key][0][0].get(Int.self), 123)
+    XCTAssertEqual(Defaults[key][0][1].get(Int.self), 456)
+    Defaults[key].append([12_131.4])
+    XCTAssertEqual(Defaults[key][1][0].get(Double.self), 12_131.4)
+  }
+
+  func testDictionaryKey() {
+    let key = Defaults.Key<[String: Defaults.AnySerializable]>("independentDictionaryAnyKey", default: ["unicorn": ""])
+    XCTAssertEqual(Defaults[key]["unicorn"]?.get(String.self), "")
+    Defaults[key]["unicorn"] = "🦄"
+    XCTAssertEqual(Defaults[key]["unicorn"]?.get(String.self), "🦄")
+    Defaults[key]["number"] = 3
+    Defaults[key]["boolean"] = true
+    XCTAssertEqual(Defaults[key]["number"]?.get(Int.self), 3)
+    XCTAssertEqual(Defaults[key]["boolean"]?.get(Bool.self), true)
+    Defaults[key]["set"] = Defaults.AnySerializable(Set([1]))
+    XCTAssertEqual(Defaults[key]["set"]!.get(Set<Int>.self)!.first, 1)
+    Defaults[key]["nil"] = nil
+    XCTAssertNil(Defaults[key]["nil"])
+  }
+
+  func testDictionaryOptionalKey() {
+    let key = Defaults.Key<[String: Defaults.AnySerializable]?>("independentDictionaryOptionalAnyKey")
+    XCTAssertNil(Defaults[key])
+    Defaults[key] = ["unicorn": "🦄"]
+    XCTAssertEqual(Defaults[key]?["unicorn"]?.get(String.self), "🦄")
+    Defaults[key]?["number"] = 3
+    Defaults[key]?["boolean"] = true
+    XCTAssertEqual(Defaults[key]?["number"]?.get(Int.self), 3)
+    XCTAssertEqual(Defaults[key]?["boolean"]?.get(Bool.self), true)
+  }
+
+  func testDictionaryArrayKey() {
+    let key = Defaults.Key<[String: [Defaults.AnySerializable]]>("independentDictionaryArrayAnyKey", default: ["number": [1]])
+    XCTAssertEqual(Defaults[key]["number"]?[0].get(Int.self), 1)
+    Defaults[key]["number"]?.append(2)
+    Defaults[key]["unicorn"] = ["No.1 🦄"]
+    Defaults[key]["unicorn"]?.append("No.2 🦄")
+    Defaults[key]["unicorn"]?.append("No.3 🦄")
+    Defaults[key]["boolean"] = [true]
+    Defaults[key]["boolean"]?.append(false)
+    XCTAssertEqual(Defaults[key]["number"]?[1].get(Int.self), 2)
+    XCTAssertEqual(Defaults[key]["unicorn"]?[0].get(String.self), "No.1 🦄")
+    XCTAssertEqual(Defaults[key]["unicorn"]?[1].get(String.self), "No.2 🦄")
+    XCTAssertEqual(Defaults[key]["unicorn"]?[2].get(String.self), "No.3 🦄")
+    XCTAssertTrue(Defaults[key]["boolean"]![0].get(Bool.self)!)
+    XCTAssertFalse(Defaults[key]["boolean"]![1].get(Bool.self)!)
+  }
+
+  func testType() {
+    XCTAssertEqual(Defaults[.anyKey].get(String.self), "🦄")
+    Defaults[.anyKey] = 123
+    XCTAssertEqual(Defaults[.anyKey].get(Int.self), 123)
+  }
+
+  func testArrayType() {
+    XCTAssertEqual(Defaults[.anyArrayKey][0].get(String.self), "No.1 🦄")
+    XCTAssertEqual(Defaults[.anyArrayKey][1].get(String.self), "No.2 🦄")
+    Defaults[.anyArrayKey].append(123)
+    XCTAssertEqual(Defaults[.anyArrayKey][2].get(Int.self), 123)
+  }
+
+  func testDictionaryType() {
+    XCTAssertEqual(Defaults[.anyDictionaryKey]["unicorn"]?.get(String.self), "🦄")
+    Defaults[.anyDictionaryKey]["number"] = 3
+    XCTAssertEqual(Defaults[.anyDictionaryKey]["number"]?.get(Int.self), 3)
+    Defaults[.anyDictionaryKey]["boolean"] = true
+    XCTAssertTrue(Defaults[.anyDictionaryKey]["boolean"]!.get(Bool.self)!)
+    Defaults[.anyDictionaryKey]["array"] = [1, 2]
+    if let array = Defaults[.anyDictionaryKey]["array"]?.get([Int].self) {
+      XCTAssertEqual(array[0], 1)
+      XCTAssertEqual(array[1], 2)
+    }
+  }
+
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
+  func testObserveKeyCombine() {
+    let key = Defaults.Key<Defaults.AnySerializable>("observeAnyKeyCombine", default: 123)
+    let expect = expectation(description: "Observation closure being called")
+
+    let publisher = Defaults
+      .publisher(key, options: [])
+      .map { ($0.oldValue, $0.newValue) }
+      .collect(2)
+
+    let expectedValue: [(Defaults.AnySerializable, Defaults.AnySerializable)] = [(123, "🦄"), ("🦄", 123)]
+
+    let cancellable = publisher.sink { tuples in
+      for (index, expected) in expectedValue.enumerated() {
+        if (tuples[index].0.get(Int.self) != nil) {
+          XCTAssertEqual(expected.0.get(Int.self), tuples[index].0.get(Int.self))
+          XCTAssertEqual(expected.1.get(String.self), tuples[index].1.get(String.self))
+        } else {
+          XCTAssertEqual(expected.0.get(String.self), tuples[index].0.get(String.self))
+          XCTAssertEqual(expected.1.get(Int.self), tuples[index].1.get(Int.self))
+        }
+      }
+
+      expect.fulfill()
+    }
+
+    Defaults[key] = "🦄"
+    Defaults.reset(key)
+    cancellable.cancel()
+
+    waitForExpectations(timeout: 10)
+  }
+
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
+  func testObserveOptionalKeyCombine() {
+    let key = Defaults.Key<Defaults.AnySerializable?>("observeAnyOptionalKeyCombine")
+    let expect = expectation(description: "Observation closure being called")
+
+    let publisher = Defaults
+      .publisher(key, options: [])
+      .map { ($0.oldValue, $0.newValue) }
+      .collect(3)
+
+    let expectedValue: [(Defaults.AnySerializable?, Defaults.AnySerializable?)] = [(nil, 123), (123, "🦄"), ("🦄", nil)]
+
+    let cancellable = publisher.sink { tuples in
+      for (index, expected) in expectedValue.enumerated() {
+        if (tuples[index].0?.get(Int.self) != nil) {
+          XCTAssertEqual(expected.0?.get(Int.self), tuples[index].0?.get(Int.self))
+          XCTAssertEqual(expected.1?.get(String.self), tuples[index].1?.get(String.self))
+        } else if (tuples[index].0?.get(String.self) != nil) {
+          XCTAssertEqual(tuples[index].0?.get(String.self), tuples[index].0?.get(String.self))
+          XCTAssertNil(tuples[index].1)
+        } else {
+          XCTAssertNil(tuples[index].0)
+          XCTAssertEqual(expected.1?.get(Int.self), tuples[index].1?.get(Int.self))
+        }
+      }
+
+      expect.fulfill()
+    }
+
+    Defaults[key] = 123
+    Defaults[key] = "🦄"
+    Defaults.reset(key)
+    cancellable.cancel()
+
+    waitForExpectations(timeout: 10)
+  }
+
+  func testObserveKey() {
+    let key = Defaults.Key<Defaults.AnySerializable>("observeAnyKey", default: 123)
+    let expect = expectation(description: "Observation closure being called")
+
+    var observation: Defaults.Observation!
+    observation = Defaults.observe(key, options: []) { change in
+      XCTAssertEqual(change.oldValue.get(Int.self), 123)
+      XCTAssertEqual(change.newValue.get(String.self), "🦄")
+      observation.invalidate()
+      expect.fulfill()
+    }
+
+    Defaults[key] = "🦄"
+    observation.invalidate()
+
+    waitForExpectations(timeout: 10)
+  }
+
+  func testObserveOptionalKey() {
+    let key = Defaults.Key<Defaults.AnySerializable?>("observeAnyOptionalKey")
+    let expect = expectation(description: "Observation closure being called")
+
+    var observation: Defaults.Observation!
+    observation = Defaults.observe(key, options: []) { change in
+      XCTAssertNil(change.oldValue)
+      XCTAssertEqual(change.newValue?.get(String.self), "🦄")
+      observation.invalidate()
+      expect.fulfill()
+    }
+
+    Defaults[key] = "🦄"
+    observation.invalidate()
+
+    waitForExpectations(timeout: 10)
+  }
+}

--- a/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
+++ b/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
@@ -3,441 +3,457 @@ import Foundation
 import XCTest
 
 private enum mime: String, Defaults.Serializable {
-  case JSON = "application/json"
+	case JSON = "application/json"
+	case STREAM = "application/octet-stream"
 }
 
 private struct CodableUnicorn: Defaults.Serializable, Codable {
-  let is_missing: Bool
+	let is_missing: Bool
 }
 
 private struct Unicorn: Defaults.Serializable, Hashable {
-  static let bridge = UnicornBridge()
-  let is_missing: Bool
+	static let bridge = UnicornBridge()
+	let is_missing: Bool
 }
 
 private struct UnicornBridge: Defaults.Bridge {
-  typealias Value = Unicorn
-  typealias Serializable = Bool
+	typealias Value = Unicorn
+	typealias Serializable = Bool
 
-  func serialize(_ value: Value?) -> Serializable? {
-    value?.is_missing
-  }
+	func serialize(_ value: Value?) -> Serializable? {
+		value?.is_missing
+	}
 
-  func deserialize(_ object: Serializable?) -> Value? {
-    return Value(is_missing: object!)
-  }
+	func deserialize(_ object: Serializable?) -> Value? {
+		Value(is_missing: object!)
+	}
 }
 
 extension Defaults.Keys {
-  fileprivate static let magic = Key<[String: Defaults.AnySerializable]>("magic", default: [:])
-  fileprivate static let anyKey = Key<Defaults.AnySerializable>("anyKey", default: "🦄")
-  fileprivate static let anyArrayKey = Key<[Defaults.AnySerializable]>("anyArrayKey", default: ["No.1 🦄", "No.2 🦄"])
-  fileprivate static let anyDictionaryKey = Key<[String: Defaults.AnySerializable]>("anyDictionaryKey", default: ["unicorn": "🦄"])
+	fileprivate static let magic = Key<[String: Defaults.AnySerializable]>("magic", default: [:])
+	fileprivate static let anyKey = Key<Defaults.AnySerializable>("anyKey", default: "🦄")
+	fileprivate static let anyArrayKey = Key<[Defaults.AnySerializable]>("anyArrayKey", default: ["No.1 🦄", "No.2 🦄"])
+	fileprivate static let anyDictionaryKey = Key<[String: Defaults.AnySerializable]>("anyDictionaryKey", default: ["unicorn": "🦄"])
 }
 
 final class DefaultsAnySerializableTests: XCTestCase {
-  override func setUp() {
-    super.setUp()
-    Defaults.removeAll()
-  }
+	override func setUp() {
+		super.setUp()
+		Defaults.removeAll()
+	}
 
-  override func tearDown() {
-    super.tearDown()
-    Defaults.removeAll()
-  }
+	override func tearDown() {
+		super.tearDown()
+		Defaults.removeAll()
+	}
 
-  func testReadMeExample() {
-    Defaults[.magic]["unicorn"] = "🦄"
-    Defaults[.magic]["number"] = 3
-    Defaults[.magic]["boolean"] = true
-    Defaults[.magic]["enum"] = Defaults.AnySerializable(mime.JSON)
-    XCTAssertEqual(Defaults[.magic]["unicorn"]?.get(String.self), "🦄")
-    XCTAssertEqual(Defaults[.magic]["number"]?.get(Int.self) , 3)
-    XCTAssertEqual(Defaults[.magic]["boolean"]?.get(Bool.self) , true)
-    XCTAssertEqual(Defaults[.magic]["enum"]?.get(mime.self) , mime.JSON)
-  }
+	func testReadMeExample() {
+		let any = Defaults.Key<Defaults.AnySerializable>("anyKey", default: Defaults.AnySerializable(mime.JSON))
+		if let mimeType: mime = Defaults[any] {
+			XCTAssertEqual(mimeType, mime.JSON)
+		}
+		Defaults[any] = mime.STREAM
+		if let mimeType: mime = Defaults[any] {
+			XCTAssertEqual(mimeType, mime.STREAM)
+		}
+		Defaults[any].set(mime.JSON)
+		if let mimeType: mime = Defaults[any].get() {
+			XCTAssertEqual(mimeType, mime.JSON)
+		}
+		Defaults[.magic]["unicorn"] = "🦄"
+		Defaults[.magic]["number"] = 3
+		Defaults[.magic]["boolean"] = true
+		Defaults[.magic]["enum"] = Defaults.AnySerializable(mime.JSON)
+		XCTAssertEqual(Defaults[.magic]["unicorn"], "🦄")
+		XCTAssertEqual(Defaults[.magic]["number"], 3)
+		XCTAssertEqual(Defaults[.magic]["boolean"], true)
+		XCTAssertEqual(Defaults[.magic]["enum"]?.get(), mime.JSON)
+		Defaults[.magic]["enum"]?.set(mime.STREAM)
+		if let value: String = Defaults[.magic]["unicorn"]?.get() {
+			XCTAssertEqual(value, "🦄")
+		}
+		if let mimeType: mime = Defaults[.magic]["enum"]?.get() {
+			XCTAssertEqual(mimeType, mime.STREAM)
+		}
+	}
 
-  func testKey() {
-    // Test Int
-    let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
-    XCTAssertEqual(Defaults[any].get(Int.self) , 121_314)
-    // Test Int8
-    let int8 = Int8.max
-    Defaults[any] = Defaults.AnySerializable(int8)
-    XCTAssertEqual(Defaults[any].get(Int8.self), int8)
-    // Test Int16
-    let int16 = Int16.max
-    Defaults[any] = Defaults.AnySerializable(int16)
-    XCTAssertEqual(Defaults[any].get(Int16.self), int16)
-    // Test Int32
-    let int32 = Int32.max
-    Defaults[any] = Defaults.AnySerializable(int32)
-    XCTAssertEqual(Defaults[any].get(Int32.self), int32)
-    // Test Int64
-    let int64 = Int64.max
-    Defaults[any] = Defaults.AnySerializable(int64)
-    XCTAssertEqual(Defaults[any].get(Int64.self), int64)
-    // Test UInt
-    let uint = UInt.max
-    Defaults[any] = Defaults.AnySerializable(uint)
-    XCTAssertEqual(Defaults[any].get(UInt.self), uint)
-    // Test UInt8
-    let uint8 = UInt8.max
-    Defaults[any] = Defaults.AnySerializable(uint8)
-    XCTAssertEqual(Defaults[any].get(UInt8.self), uint8)
-    // Test UInt16
-    let uint16 = UInt16.max
-    Defaults[any] = Defaults.AnySerializable(uint16)
-    XCTAssertEqual(Defaults[any].get(UInt16.self), uint16)
-    // Test UInt32
-    let uint32 = UInt32.max
-    Defaults[any] = Defaults.AnySerializable(uint32)
-    XCTAssertEqual(Defaults[any].get(UInt32.self), uint32)
-    // Test UInt64
-    let uint64 = UInt64.max
-    Defaults[any] = Defaults.AnySerializable(uint64)
-    XCTAssertEqual(Defaults[any].get(UInt64.self), uint64)
-    // Test Double
-    Defaults[any] = 12_131.4
-    XCTAssertEqual(Defaults[any].get(Double.self), 12_131.4)
-    // Test Bool
-    Defaults[any] = true
-    XCTAssertTrue(Defaults[any].get(Bool.self)!)
-    // Test String
-    Defaults[any] = "121314"
-    XCTAssertEqual(Defaults[any].get(String.self), "121314")
-    // Test Float
-    let float: Float = 12_131.4
-    Defaults[any] = Defaults.AnySerializable(float)
-    XCTAssertEqual(Defaults[any].get(Float.self), float)
-    // Test Date
-    let date = Date()
-    Defaults[any] = Defaults.AnySerializable(date)
-    XCTAssertEqual(Defaults[any].get(Date.self), date)
-    // Test Data
-    let data = "121314".data(using: .utf8)
-    Defaults[any] = Defaults.AnySerializable(data)
-    XCTAssertEqual(Defaults[any].get(Data.self), data)
-    // Test Array
-    Defaults[any] = [1, 2, 3]
-    if let array = Defaults[any].get([Int].self) {
-      XCTAssertEqual(array[0], 1)
-      XCTAssertEqual(array[1], 2)
-      XCTAssertEqual(array[2], 3)
-    }
-    // Test Dictionary
-    Defaults[any] = ["unicorn": "🦄", "boolean": true, "number": 3]
-    if let dictionary = Defaults[any].get([String: Defaults.AnySerializable].self) {
-      XCTAssertEqual(dictionary["unicorn"]?.get(String.self), "🦄")
-      XCTAssertTrue(dictionary["boolean"]!.get(Bool.self)!)
-      XCTAssertEqual(dictionary["number"]?.get(Int.self), 3)
-    }
-    // Test Set
-    Defaults[any].set(value: Set([1]))
-    XCTAssertEqual(Defaults[any].get(Set<Int>.self)?.first, 1)
-    // Test URL
-    Defaults[any].set(value: URL(string: "https://example.com")!)
-    XCTAssertEqual(Defaults[any].get(URL.self)!, URL(string: "https://example.com")!)
-    #if os(macOS)
-    // Test NSColor
-    Defaults[any].set(value: NSColor(red: CGFloat(103) / CGFloat(0xFF), green: CGFloat(132) / CGFloat(0xFF), blue: CGFloat(255) / CGFloat(0xFF), alpha: 0.987))
-    XCTAssertEqual(Defaults[any].get(NSColor.self)!.alphaComponent, 0.987)
-    #else
-    // Test UIColor
-    Defaults[any] = Defaults.AnySerializable(UIColor(red: CGFloat(103) / CGFloat(0xFF), green: CGFloat(132) / CGFloat(0xFF), blue: CGFloat(255) / CGFloat(0xFF), alpha: 0.654))
-    XCTAssertEqual( Defaults[any].get(UIColor.self)?.cgColor.alpha, 0.654)
-    #endif
-    // Test Codable type
-    Defaults[any].set(value: CodableUnicorn(is_missing: false))
-    XCTAssertFalse(Defaults[any].get(CodableUnicorn.self)!.is_missing)
-    // Test Custom type
-    Defaults[any].set(value: Unicorn(is_missing: true))
-    XCTAssertTrue(Defaults[any].get(Unicorn.self)!.is_missing)
-    // Test nil
-    Defaults[any] = nil
-    XCTAssertEqual(Defaults[any], 121_314)
-  }
+	func testKey() {
+		// Test Int
+		let any = Defaults.Key<Defaults.AnySerializable>("independentAnyKey", default: 121_314)
+		XCTAssertEqual(Defaults[any], 121_314)
+		// Test Int8
+		let int8 = Int8.max
+		Defaults[any] = int8
+		XCTAssertEqual(Defaults[any], int8)
+		// Test Int16
+		let int16 = Int16.max
+		Defaults[any] = int16
+		XCTAssertEqual(Defaults[any], int16)
+		// Test Int32
+		let int32 = Int32.max
+		Defaults[any] = int32
+		XCTAssertEqual(Defaults[any], int32)
+		// Test Int64
+		let int64 = Int64.max
+		Defaults[any] = int64
+		XCTAssertEqual(Defaults[any], int64)
+		// Test UInt
+		let uint = UInt.max
+		Defaults[any] = uint
+		XCTAssertEqual(Defaults[any], uint)
+		// Test UInt8
+		let uint8 = UInt8.max
+		Defaults[any] = uint8
+		XCTAssertEqual(Defaults[any], uint8)
+		// Test UInt16
+		let uint16 = UInt16.max
+		Defaults[any] = uint16
+		XCTAssertEqual(Defaults[any], uint16)
+		// Test UInt32
+		let uint32 = UInt32.max
+		Defaults[any] = uint32
+		XCTAssertEqual(Defaults[any], uint32)
+		// Test UInt64
+		let uint64 = UInt64.max
+		Defaults[any] = uint64
+		XCTAssertEqual(Defaults[any], uint64)
+		// Test Double
+		Defaults[any] = 12_131.4
+		XCTAssertEqual(Defaults[any], 12_131.4)
+		// Test Bool
+		Defaults[any] = true
+		XCTAssertTrue(Defaults[any, type: Bool.self]!)
+		// Test String
+		Defaults[any] = "121314"
+		XCTAssertEqual(Defaults[any], "121314")
+		// Test Float
+		Defaults[any, type: Float.self] = 12_131.456
+		XCTAssertEqual(Defaults[any, type: Float.self], 12_131.456)
+		// Test Date
+		let date = Date()
+		Defaults[any] = date
+		XCTAssertEqual(Defaults[any, type: Date.self], date)
+		// Test Data
+		let data = "121314".data(using: .utf8)
+		Defaults[any] = data
+		XCTAssertEqual(Defaults[any], data)
+		// Test Array
+		Defaults[any] = [1, 2, 3]
+		if let array: [Int] = Defaults[any] {
+			XCTAssertEqual(array[0], 1)
+			XCTAssertEqual(array[1], 2)
+			XCTAssertEqual(array[2], 3)
+		}
+		// Test Dictionary
+		Defaults[any] = ["unicorn": "🦄", "boolean": true, "number": 3]
+		if let dictionary = Defaults[any, type: [String: Defaults.AnySerializable].self] {
+			XCTAssertEqual(dictionary["unicorn"], "🦄")
+			XCTAssertTrue(dictionary["boolean"]!.get(Bool.self)!)
+			XCTAssertEqual(dictionary["number"], 3)
+		}
+		// Test Set
+		Defaults[any] = Set([1])
+		XCTAssertEqual(Defaults[any, type: Set<Int>.self]?.first, 1)
+		// Test URL
+		Defaults[any] = URL(string: "https://example.com")!
+		XCTAssertEqual(Defaults[any]!, URL(string: "https://example.com")!)
+		#if os(macOS)
+		// Test NSColor
+		Defaults[any] = NSColor(red: CGFloat(103) / CGFloat(0xFF), green: CGFloat(132) / CGFloat(0xFF), blue: CGFloat(255) / CGFloat(0xFF), alpha: 0.987)
+		XCTAssertEqual(Defaults[any, type: NSColor.self]?.alphaComponent, 0.987)
+		#else
+		// Test UIColor
+		Defaults[any] = Defaults.AnySerializable(UIColor(red: CGFloat(103) / CGFloat(0xFF), green: CGFloat(132) / CGFloat(0xFF), blue: CGFloat(255) / CGFloat(0xFF), alpha: 0.654))
+		XCTAssertEqual(Defaults[any, type: UIColor.self]?.cgColor.alpha, 0.654)
+		#endif
+		// Test Codable type
+		Defaults[any] = CodableUnicorn(is_missing: false)
+		XCTAssertFalse(Defaults[any, type: CodableUnicorn.self]!.is_missing)
+		// Test Custom type
+		Defaults[any] = Unicorn(is_missing: true)
+		XCTAssertTrue(Defaults[any, type: Unicorn.self]!.is_missing)
+		// Test nil
+		Defaults[any] = nil
+		XCTAssertEqual(Defaults[any], 121_314)
+	}
 
-  func testOptionalKey() {
-    let key = Defaults.Key<Defaults.AnySerializable?>("independentOptionalAnyKey")
-    XCTAssertNil(Defaults[key])
-    Defaults[key] = 12_131.4
-    XCTAssertEqual(Defaults[key]!.get(Double.self), 12_131.4)
-    Defaults[key] = nil
-    XCTAssertNil(Defaults[key])
-  }
+	func testOptionalKey() {
+		let key = Defaults.Key<Defaults.AnySerializable?>("independentOptionalAnyKey")
+		XCTAssertNil(Defaults[key])
+		Defaults[key] = 12_131.4
+		XCTAssertEqual(Defaults[key], 12_131.4)
+		Defaults[key] = mime.JSON
+		XCTAssertEqual(Defaults[key, type: mime.self], mime.JSON)
+		Defaults[key] = nil
+		XCTAssertNil(Defaults[key])
+	}
 
-  func testArrayKey() {
-    let key = Defaults.Key<[Defaults.AnySerializable]>("independentArrayAnyKey", default: [123, 456])
-    XCTAssertEqual(Defaults[key][0].get(Int.self), 123)
-    XCTAssertEqual(Defaults[key][1].get(Int.self), 456)
-    Defaults[key][0] = 12_131.4
-    XCTAssertEqual(Defaults[key][0].get(Double.self), 12_131.4)
-  }
+	func testArrayKey() {
+		let key = Defaults.Key<[Defaults.AnySerializable]>("independentArrayAnyKey", default: [123, 456])
+		XCTAssertEqual(Defaults[key][0], 123)
+		XCTAssertEqual(Defaults[key][1], 456)
+		Defaults[key][0] = 12_131.4
+		XCTAssertEqual(Defaults[key][0], 12_131.4)
+	}
 
-  func testSetKey() {
-    let key = Defaults.Key<Set<Defaults.AnySerializable>>("independentArrayAnyKey", default: [123])
-    XCTAssertEqual(Defaults[key].first?.get(Int.self), 123)
-    Defaults[key].insert(12_131.4)
-    XCTAssertTrue(Defaults[key].contains(12_131.4))
-    let date = Defaults.AnySerializable(Date())
-    Defaults[key].insert(date)
-    XCTAssertTrue(Defaults[key].contains(date))
-    let data = Defaults.AnySerializable("Hello World!".data(using: .utf8))
-    Defaults[key].insert(data)
-    XCTAssertTrue(Defaults[key].contains(data))
-    let int = Defaults.AnySerializable(Int.max)
-    Defaults[key].insert(int)
-    XCTAssertTrue(Defaults[key].contains(int))
-    let int8 = Defaults.AnySerializable(Int8.max)
-    Defaults[key].insert(int8)
-    XCTAssertTrue(Defaults[key].contains(int8))
-    let int16 = Defaults.AnySerializable(Int16.max)
-    Defaults[key].insert(int16)
-    XCTAssertTrue(Defaults[key].contains(int16))
-    let int32 = Defaults.AnySerializable(Int32.max)
-    Defaults[key].insert(int32)
-    XCTAssertTrue(Defaults[key].contains(int32))
-    let int64 = Defaults.AnySerializable(Int64.max)
-    Defaults[key].insert(int64)
-    XCTAssertTrue(Defaults[key].contains(int64))
-    let uint = Defaults.AnySerializable(UInt.max)
-    Defaults[key].insert(uint)
-    XCTAssertTrue(Defaults[key].contains(uint))
-    let uint8 = Defaults.AnySerializable(UInt8.max)
-    Defaults[key].insert(uint8)
-    XCTAssertTrue(Defaults[key].contains(uint8))
-    let uint16 = Defaults.AnySerializable(UInt16.max)
-    Defaults[key].insert(uint16)
-    XCTAssertTrue(Defaults[key].contains(uint16))
-    let uint32 = Defaults.AnySerializable(UInt32.max)
-    Defaults[key].insert(uint32)
-    XCTAssertTrue(Defaults[key].contains(uint32))
-    let uint64 = Defaults.AnySerializable(UInt64.max)
-    Defaults[key].insert(uint64)
-    XCTAssertTrue(Defaults[key].contains(uint64))
+	func testSetKey() {
+		let key = Defaults.Key<Set<Defaults.AnySerializable>>("independentArrayAnyKey", default: [123])
+		XCTAssertEqual(Defaults[key].first, 123)
+		Defaults[key].insert(12_131.4)
+		XCTAssertTrue(Defaults[key].contains(12_131.4))
+		let date = Defaults.AnySerializable(Date())
+		Defaults[key].insert(date)
+		XCTAssertTrue(Defaults[key].contains(date))
+		let data = Defaults.AnySerializable("Hello World!".data(using: .utf8))
+		Defaults[key].insert(data)
+		XCTAssertTrue(Defaults[key].contains(data))
+		let int = Defaults.AnySerializable(Int.max)
+		Defaults[key].insert(int)
+		XCTAssertTrue(Defaults[key].contains(int))
+		let int8 = Defaults.AnySerializable(Int8.max)
+		Defaults[key].insert(int8)
+		XCTAssertTrue(Defaults[key].contains(int8))
+		let int16 = Defaults.AnySerializable(Int16.max)
+		Defaults[key].insert(int16)
+		XCTAssertTrue(Defaults[key].contains(int16))
+		let int32 = Defaults.AnySerializable(Int32.max)
+		Defaults[key].insert(int32)
+		XCTAssertTrue(Defaults[key].contains(int32))
+		let int64 = Defaults.AnySerializable(Int64.max)
+		Defaults[key].insert(int64)
+		XCTAssertTrue(Defaults[key].contains(int64))
+		let uint = Defaults.AnySerializable(UInt.max)
+		Defaults[key].insert(uint)
+		XCTAssertTrue(Defaults[key].contains(uint))
+		let uint8 = Defaults.AnySerializable(UInt8.max)
+		Defaults[key].insert(uint8)
+		XCTAssertTrue(Defaults[key].contains(uint8))
+		let uint16 = Defaults.AnySerializable(UInt16.max)
+		Defaults[key].insert(uint16)
+		XCTAssertTrue(Defaults[key].contains(uint16))
+		let uint32 = Defaults.AnySerializable(UInt32.max)
+		Defaults[key].insert(uint32)
+		XCTAssertTrue(Defaults[key].contains(uint32))
+		let uint64 = Defaults.AnySerializable(UInt64.max)
+		Defaults[key].insert(uint64)
+		XCTAssertTrue(Defaults[key].contains(uint64))
 
-    let bool: Defaults.AnySerializable = false
-    Defaults[key].insert(bool)
-    XCTAssertTrue(Defaults[key].contains(bool))
+		let bool: Defaults.AnySerializable = false
+		Defaults[key].insert(bool)
+		XCTAssertTrue(Defaults[key].contains(bool))
 
-    let float = Defaults.AnySerializable(Float(1_213.14))
-    Defaults[key].insert(float)
-    XCTAssertTrue(Defaults[key].contains(float))
+		let float = Defaults.AnySerializable(Float(1_213.14))
+		Defaults[key].insert(float)
+		XCTAssertTrue(Defaults[key].contains(float))
 
-    let cgFloat = Defaults.AnySerializable(CGFloat(12_131.415))
-    Defaults[key].insert(cgFloat)
-    XCTAssertTrue(Defaults[key].contains(cgFloat))
+		let cgFloat = Defaults.AnySerializable(CGFloat(12_131.415))
+		Defaults[key].insert(cgFloat)
+		XCTAssertTrue(Defaults[key].contains(cgFloat))
 
-    let string = Defaults.AnySerializable("Hello World!")
-    Defaults[key].insert(string)
-    XCTAssertTrue(Defaults[key].contains(string))
+		let string = Defaults.AnySerializable("Hello World!")
+		Defaults[key].insert(string)
+		XCTAssertTrue(Defaults[key].contains(string))
 
-    let array: Defaults.AnySerializable = [1, 2, 3, 4]
-    Defaults[key].insert(array)
-    XCTAssertTrue(Defaults[key].contains(array))
+		let array: Defaults.AnySerializable = [1, 2, 3, 4]
+		Defaults[key].insert(array)
+		XCTAssertTrue(Defaults[key].contains(array))
 
-    let dictionary: Defaults.AnySerializable = ["Hello": "World!"]
-    Defaults[key].insert(dictionary)
-    XCTAssertTrue(Defaults[key].contains(dictionary))
+		let dictionary: Defaults.AnySerializable = ["Hello": "World!"]
+		Defaults[key].insert(dictionary)
+		XCTAssertTrue(Defaults[key].contains(dictionary))
 
-    let unicorn = Defaults.AnySerializable(Unicorn(is_missing: true))
-    Defaults[key].insert(unicorn)
-    XCTAssertTrue(Defaults[key].contains(unicorn))
-  }
+		let unicorn = Defaults.AnySerializable(Unicorn(is_missing: true))
+		Defaults[key].insert(unicorn)
+		XCTAssertTrue(Defaults[key].contains(unicorn))
+	}
 
-  func testArrayOptionalKey() {
-    let key = Defaults.Key<[Defaults.AnySerializable]?>("testArrayOptionalAnyKey")
-    XCTAssertNil(Defaults[key])
-    Defaults[key] = [123]
-    Defaults[key]?.append(456)
-    XCTAssertEqual(Defaults[key]![0].get(Int.self), 123)
-    XCTAssertEqual(Defaults[key]![1].get(Int.self), 456)
-    Defaults[key]![0] = 12_131.4
-    XCTAssertEqual(Defaults[key]![0].get(Double.self), 12_131.4)
-  }
+	func testArrayOptionalKey() {
+		let key = Defaults.Key<[Defaults.AnySerializable]?>("testArrayOptionalAnyKey")
+		XCTAssertNil(Defaults[key])
+		Defaults[key] = [123]
+		Defaults[key]?.append(456)
+		XCTAssertEqual(Defaults[key]![0], 123)
+		XCTAssertEqual(Defaults[key]![1], 456)
+		Defaults[key]![0] = 12_131.4
+		XCTAssertEqual(Defaults[key]![0], 12_131.4)
+	}
 
-  func testNestedArrayKey() {
-    let key = Defaults.Key<[[Defaults.AnySerializable]]>("testNestedArrayAnyKey", default: [[123]])
-    Defaults[key][0].append(456)
-    XCTAssertEqual(Defaults[key][0][0].get(Int.self), 123)
-    XCTAssertEqual(Defaults[key][0][1].get(Int.self), 456)
-    Defaults[key].append([12_131.4])
-    XCTAssertEqual(Defaults[key][1][0].get(Double.self), 12_131.4)
-  }
+	func testNestedArrayKey() {
+		let key = Defaults.Key<[[Defaults.AnySerializable]]>("testNestedArrayAnyKey", default: [[123]])
+		Defaults[key][0].append(456)
+		XCTAssertEqual(Defaults[key][0][0], 123)
+		XCTAssertEqual(Defaults[key][0][1], 456)
+		Defaults[key].append([12_131.4])
+		XCTAssertEqual(Defaults[key][1][0], 12_131.4)
+	}
 
-  func testDictionaryKey() {
-    let key = Defaults.Key<[String: Defaults.AnySerializable]>("independentDictionaryAnyKey", default: ["unicorn": ""])
-    XCTAssertEqual(Defaults[key]["unicorn"]?.get(String.self), "")
-    Defaults[key]["unicorn"] = "🦄"
-    XCTAssertEqual(Defaults[key]["unicorn"]?.get(String.self), "🦄")
-    Defaults[key]["number"] = 3
-    Defaults[key]["boolean"] = true
-    XCTAssertEqual(Defaults[key]["number"]?.get(Int.self), 3)
-    XCTAssertEqual(Defaults[key]["boolean"]?.get(Bool.self), true)
-    Defaults[key]["set"] = Defaults.AnySerializable(Set([1]))
-    XCTAssertEqual(Defaults[key]["set"]!.get(Set<Int>.self)!.first, 1)
-    Defaults[key]["nil"] = nil
-    XCTAssertNil(Defaults[key]["nil"])
-  }
+	func testDictionaryKey() {
+		let key = Defaults.Key<[String: Defaults.AnySerializable]>("independentDictionaryAnyKey", default: ["unicorn": ""])
+		XCTAssertEqual(Defaults[key]["unicorn"], "")
+		Defaults[key]["unicorn"] = "🦄"
+		XCTAssertEqual(Defaults[key]["unicorn"], "🦄")
+		Defaults[key]["number"] = 3
+		Defaults[key]["boolean"] = true
+		XCTAssertEqual(Defaults[key]["number"], 3)
+		XCTAssertEqual(Defaults[key]["boolean"], true)
+		Defaults[key]["set"] = Defaults.AnySerializable(Set([1]))
+		XCTAssertEqual(Defaults[key]["set"]!.get(Set<Int>.self)!.first, 1)
+		Defaults[key]["nil"] = nil
+		XCTAssertNil(Defaults[key]["nil"])
+	}
 
-  func testDictionaryOptionalKey() {
-    let key = Defaults.Key<[String: Defaults.AnySerializable]?>("independentDictionaryOptionalAnyKey")
-    XCTAssertNil(Defaults[key])
-    Defaults[key] = ["unicorn": "🦄"]
-    XCTAssertEqual(Defaults[key]?["unicorn"]?.get(String.self), "🦄")
-    Defaults[key]?["number"] = 3
-    Defaults[key]?["boolean"] = true
-    XCTAssertEqual(Defaults[key]?["number"]?.get(Int.self), 3)
-    XCTAssertEqual(Defaults[key]?["boolean"]?.get(Bool.self), true)
-  }
+	func testDictionaryOptionalKey() {
+		let key = Defaults.Key<[String: Defaults.AnySerializable]?>("independentDictionaryOptionalAnyKey")
+		XCTAssertNil(Defaults[key])
+		Defaults[key] = ["unicorn": "🦄"]
+		XCTAssertEqual(Defaults[key]?["unicorn"], "🦄")
+		Defaults[key]?["number"] = 3
+		Defaults[key]?["boolean"] = true
+		XCTAssertEqual(Defaults[key]?["number"], 3)
+		XCTAssertEqual(Defaults[key]?["boolean"], true)
+	}
 
-  func testDictionaryArrayKey() {
-    let key = Defaults.Key<[String: [Defaults.AnySerializable]]>("independentDictionaryArrayAnyKey", default: ["number": [1]])
-    XCTAssertEqual(Defaults[key]["number"]?[0].get(Int.self), 1)
-    Defaults[key]["number"]?.append(2)
-    Defaults[key]["unicorn"] = ["No.1 🦄"]
-    Defaults[key]["unicorn"]?.append("No.2 🦄")
-    Defaults[key]["unicorn"]?.append("No.3 🦄")
-    Defaults[key]["boolean"] = [true]
-    Defaults[key]["boolean"]?.append(false)
-    XCTAssertEqual(Defaults[key]["number"]?[1].get(Int.self), 2)
-    XCTAssertEqual(Defaults[key]["unicorn"]?[0].get(String.self), "No.1 🦄")
-    XCTAssertEqual(Defaults[key]["unicorn"]?[1].get(String.self), "No.2 🦄")
-    XCTAssertEqual(Defaults[key]["unicorn"]?[2].get(String.self), "No.3 🦄")
-    XCTAssertTrue(Defaults[key]["boolean"]![0].get(Bool.self)!)
-    XCTAssertFalse(Defaults[key]["boolean"]![1].get(Bool.self)!)
-  }
+	func testDictionaryArrayKey() {
+		let key = Defaults.Key<[String: [Defaults.AnySerializable]]>("independentDictionaryArrayAnyKey", default: ["number": [1]])
+		XCTAssertEqual(Defaults[key]["number"]?[0], 1)
+		Defaults[key]["number"]?.append(2)
+		Defaults[key]["unicorn"] = ["No.1 🦄"]
+		Defaults[key]["unicorn"]?.append("No.2 🦄")
+		Defaults[key]["unicorn"]?.append("No.3 🦄")
+		Defaults[key]["boolean"] = [true]
+		Defaults[key]["boolean"]?.append(false)
+		XCTAssertEqual(Defaults[key]["number"]?[1], 2)
+		XCTAssertEqual(Defaults[key]["unicorn"]?[0], "No.1 🦄")
+		XCTAssertEqual(Defaults[key]["unicorn"]?[1], "No.2 🦄")
+		XCTAssertEqual(Defaults[key]["unicorn"]?[2], "No.3 🦄")
+		XCTAssertTrue(Defaults[key]["boolean"]![0].get(Bool.self)!)
+		XCTAssertFalse(Defaults[key]["boolean"]![1].get(Bool.self)!)
+	}
 
-  func testType() {
-    XCTAssertEqual(Defaults[.anyKey].get(String.self), "🦄")
-    Defaults[.anyKey] = 123
-    XCTAssertEqual(Defaults[.anyKey].get(Int.self), 123)
-  }
+	func testType() {
+		XCTAssertEqual(Defaults[.anyKey], "🦄")
+		Defaults[.anyKey] = 123
+		XCTAssertEqual(Defaults[.anyKey], 123)
+	}
 
-  func testArrayType() {
-    XCTAssertEqual(Defaults[.anyArrayKey][0].get(String.self), "No.1 🦄")
-    XCTAssertEqual(Defaults[.anyArrayKey][1].get(String.self), "No.2 🦄")
-    Defaults[.anyArrayKey].append(123)
-    XCTAssertEqual(Defaults[.anyArrayKey][2].get(Int.self), 123)
-  }
+	func testArrayType() {
+		XCTAssertEqual(Defaults[.anyArrayKey][0], "No.1 🦄")
+		XCTAssertEqual(Defaults[.anyArrayKey][1], "No.2 🦄")
+		Defaults[.anyArrayKey].append(123)
+		XCTAssertEqual(Defaults[.anyArrayKey][2], 123)
+	}
 
-  func testDictionaryType() {
-    XCTAssertEqual(Defaults[.anyDictionaryKey]["unicorn"]?.get(String.self), "🦄")
-    Defaults[.anyDictionaryKey]["number"] = 3
-    XCTAssertEqual(Defaults[.anyDictionaryKey]["number"]?.get(Int.self), 3)
-    Defaults[.anyDictionaryKey]["boolean"] = true
-    XCTAssertTrue(Defaults[.anyDictionaryKey]["boolean"]!.get(Bool.self)!)
-    Defaults[.anyDictionaryKey]["array"] = [1, 2]
-    if let array = Defaults[.anyDictionaryKey]["array"]?.get([Int].self) {
-      XCTAssertEqual(array[0], 1)
-      XCTAssertEqual(array[1], 2)
-    }
-  }
+	func testDictionaryType() {
+		XCTAssertEqual(Defaults[.anyDictionaryKey]["unicorn"], "🦄")
+		Defaults[.anyDictionaryKey]["number"] = 3
+		XCTAssertEqual(Defaults[.anyDictionaryKey]["number"], 3)
+		Defaults[.anyDictionaryKey]["boolean"] = true
+		XCTAssertTrue(Defaults[.anyDictionaryKey]["boolean"]!.get(Bool.self)!)
+		Defaults[.anyDictionaryKey]["array"] = [1, 2]
+		if let array = Defaults[.anyDictionaryKey]["array"]?.get([Int].self) {
+			XCTAssertEqual(array[0], 1)
+			XCTAssertEqual(array[1], 2)
+		}
+	}
 
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
-  func testObserveKeyCombine() {
-    let key = Defaults.Key<Defaults.AnySerializable>("observeAnyKeyCombine", default: 123)
-    let expect = expectation(description: "Observation closure being called")
+	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
+	func testObserveKeyCombine() {
+		let key = Defaults.Key<Defaults.AnySerializable>("observeAnyKeyCombine", default: 123)
+		let expect = expectation(description: "Observation closure being called")
 
-    let publisher = Defaults
-      .publisher(key, options: [])
-      .map { ($0.oldValue, $0.newValue) }
-      .collect(2)
+		let publisher = Defaults
+			.publisher(key, options: [])
+			.map { ($0.oldValue, $0.newValue) }
+			.collect(2)
 
-    let expectedValue: [(Defaults.AnySerializable, Defaults.AnySerializable)] = [(123, "🦄"), ("🦄", 123)]
+		let expectedValue: [(Defaults.AnySerializable, Defaults.AnySerializable)] = [(123, "🦄"), ("🦄", 123)]
 
-    let cancellable = publisher.sink { tuples in
-      for (index, expected) in expectedValue.enumerated() {
-        if (tuples[index].0.get(Int.self) != nil) {
-          XCTAssertEqual(expected.0.get(Int.self), tuples[index].0.get(Int.self))
-          XCTAssertEqual(expected.1.get(String.self), tuples[index].1.get(String.self))
-        } else {
-          XCTAssertEqual(expected.0.get(String.self), tuples[index].0.get(String.self))
-          XCTAssertEqual(expected.1.get(Int.self), tuples[index].1.get(Int.self))
-        }
-      }
+		let cancellable = publisher.sink { tuples in
+			for (index, expected) in expectedValue.enumerated() {
+				XCTAssertEqual(expected.0, tuples[index].0)
+				XCTAssertEqual(expected.1, tuples[index].1)
+			}
 
-      expect.fulfill()
-    }
+			expect.fulfill()
+		}
 
-    Defaults[key] = "🦄"
-    Defaults.reset(key)
-    cancellable.cancel()
+		Defaults[key] = "🦄"
+		Defaults.reset(key)
+		cancellable.cancel()
 
-    waitForExpectations(timeout: 10)
-  }
+		waitForExpectations(timeout: 10)
+	}
 
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
-  func testObserveOptionalKeyCombine() {
-    let key = Defaults.Key<Defaults.AnySerializable?>("observeAnyOptionalKeyCombine")
-    let expect = expectation(description: "Observation closure being called")
+	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
+	func testObserveOptionalKeyCombine() {
+		let key = Defaults.Key<Defaults.AnySerializable?>("observeAnyOptionalKeyCombine")
+		let expect = expectation(description: "Observation closure being called")
 
-    let publisher = Defaults
-      .publisher(key, options: [])
-      .map { ($0.oldValue, $0.newValue) }
-      .collect(3)
+		let publisher = Defaults
+			.publisher(key, options: [])
+			.map { ($0.oldValue, $0.newValue) }
+			.collect(3)
 
-    let expectedValue: [(Defaults.AnySerializable?, Defaults.AnySerializable?)] = [(nil, 123), (123, "🦄"), ("🦄", nil)]
+		let expectedValue: [(Defaults.AnySerializable?, Defaults.AnySerializable?)] = [(nil, 123), (123, "🦄"), ("🦄", nil)]
 
-    let cancellable = publisher.sink { tuples in
-      for (index, expected) in expectedValue.enumerated() {
-        if (tuples[index].0?.get(Int.self) != nil) {
-          XCTAssertEqual(expected.0?.get(Int.self), tuples[index].0?.get(Int.self))
-          XCTAssertEqual(expected.1?.get(String.self), tuples[index].1?.get(String.self))
-        } else if (tuples[index].0?.get(String.self) != nil) {
-          XCTAssertEqual(tuples[index].0?.get(String.self), tuples[index].0?.get(String.self))
-          XCTAssertNil(tuples[index].1)
-        } else {
-          XCTAssertNil(tuples[index].0)
-          XCTAssertEqual(expected.1?.get(Int.self), tuples[index].1?.get(Int.self))
-        }
-      }
+		let cancellable = publisher.sink { tuples in
+			for (index, expected) in expectedValue.enumerated() {
+				if tuples[index].0?.get(Int.self) != nil {
+					XCTAssertEqual(expected.0, tuples[index].0)
+					XCTAssertEqual(expected.1, tuples[index].1)
+				} else if tuples[index].0?.get(String.self) != nil {
+					XCTAssertEqual(expected.0, tuples[index].0)
+					XCTAssertNil(tuples[index].1)
+				} else {
+					XCTAssertNil(tuples[index].0)
+					XCTAssertEqual(expected.1, tuples[index].1)
+				}
+			}
 
-      expect.fulfill()
-    }
+			expect.fulfill()
+		}
 
-    Defaults[key] = 123
-    Defaults[key] = "🦄"
-    Defaults.reset(key)
-    cancellable.cancel()
+		Defaults[key] = 123
+		Defaults[key] = "🦄"
+		Defaults.reset(key)
+		cancellable.cancel()
 
-    waitForExpectations(timeout: 10)
-  }
+		waitForExpectations(timeout: 10)
+	}
 
-  func testObserveKey() {
-    let key = Defaults.Key<Defaults.AnySerializable>("observeAnyKey", default: 123)
-    let expect = expectation(description: "Observation closure being called")
+	func testObserveKey() {
+		let key = Defaults.Key<Defaults.AnySerializable>("observeAnyKey", default: 123)
+		let expect = expectation(description: "Observation closure being called")
 
-    var observation: Defaults.Observation!
-    observation = Defaults.observe(key, options: []) { change in
-      XCTAssertEqual(change.oldValue.get(Int.self), 123)
-      XCTAssertEqual(change.newValue.get(String.self), "🦄")
-      observation.invalidate()
-      expect.fulfill()
-    }
+		var observation: Defaults.Observation!
+		observation = Defaults.observe(key, options: []) { change in
+			XCTAssertEqual(change.oldValue, 123)
+			XCTAssertEqual(change.newValue, "🦄")
+			observation.invalidate()
+			expect.fulfill()
+		}
 
-    Defaults[key] = "🦄"
-    observation.invalidate()
+		Defaults[key] = "🦄"
+		observation.invalidate()
 
-    waitForExpectations(timeout: 10)
-  }
+		waitForExpectations(timeout: 10)
+	}
 
-  func testObserveOptionalKey() {
-    let key = Defaults.Key<Defaults.AnySerializable?>("observeAnyOptionalKey")
-    let expect = expectation(description: "Observation closure being called")
+	func testObserveOptionalKey() {
+		let key = Defaults.Key<Defaults.AnySerializable?>("observeAnyOptionalKey")
+		let expect = expectation(description: "Observation closure being called")
 
-    var observation: Defaults.Observation!
-    observation = Defaults.observe(key, options: []) { change in
-      XCTAssertNil(change.oldValue)
-      XCTAssertEqual(change.newValue?.get(String.self), "🦄")
-      observation.invalidate()
-      expect.fulfill()
-    }
+		var observation: Defaults.Observation!
+		observation = Defaults.observe(key, options: []) { change in
+			XCTAssertNil(change.oldValue)
+			XCTAssertEqual(change.newValue, "🦄")
+			observation.invalidate()
+			expect.fulfill()
+		}
 
-    Defaults[key] = "🦄"
-    observation.invalidate()
+		Defaults[key] = "🦄"
+		observation.invalidate()
 
-    waitForExpectations(timeout: 10)
-  }
+		waitForExpectations(timeout: 10)
+	}
 }

--- a/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
+++ b/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
@@ -49,11 +49,11 @@ final class DefaultsAnySerializableTests: XCTestCase {
 
 	func testReadMeExample() {
 		let any = Defaults.Key<Defaults.AnySerializable>("anyKey", default: Defaults.AnySerializable(mime.JSON))
-		if let mimeType: mime = Defaults[any] {
+		if let mimeType: mime = Defaults[any].get() {
 			XCTAssertEqual(mimeType, mime.JSON)
 		}
-		Defaults[any] = mime.STREAM
-		if let mimeType: mime = Defaults[any] {
+		Defaults[any].set(mime.STREAM)
+		if let mimeType: mime = Defaults[any].get() {
 			XCTAssertEqual(mimeType, mime.STREAM)
 		}
 		Defaults[any].set(mime.JSON)
@@ -77,6 +77,13 @@ final class DefaultsAnySerializableTests: XCTestCase {
 		if let mimeType: mime = Defaults[.magic]["enum"]?.get() {
 			XCTAssertEqual(mimeType, mime.STREAM)
 		}
+		let anyArray = Defaults.Key<[Defaults.AnySerializable]>("anyArrayKey", default: [Defaults.AnySerializable(mime.JSON)])
+
+		if let mimeType: mime = Defaults[anyArray][0].get() {
+			XCTAssertEqual(mimeType, mime.JSON) //=> "application/json"
+		}
+		Defaults[anyArray].append(123)
+		XCTAssertEqual(Defaults[anyArray][1].get(Int.self), 123)
 	}
 
 	func testKey() {
@@ -85,95 +92,95 @@ final class DefaultsAnySerializableTests: XCTestCase {
 		XCTAssertEqual(Defaults[any], 121_314)
 		// Test Int8
 		let int8 = Int8.max
-		Defaults[any] = int8
-		XCTAssertEqual(Defaults[any], int8)
+		Defaults[any].set(int8)
+		XCTAssertEqual(Defaults[any].get(), int8)
 		// Test Int16
 		let int16 = Int16.max
-		Defaults[any] = int16
-		XCTAssertEqual(Defaults[any], int16)
+		Defaults[any].set(int16)
+		XCTAssertEqual(Defaults[any].get(), int16)
 		// Test Int32
 		let int32 = Int32.max
-		Defaults[any] = int32
-		XCTAssertEqual(Defaults[any], int32)
+		Defaults[any].set(int32)
+		XCTAssertEqual(Defaults[any].get(), int32)
 		// Test Int64
 		let int64 = Int64.max
-		Defaults[any] = int64
-		XCTAssertEqual(Defaults[any], int64)
+		Defaults[any].set(int64)
+		XCTAssertEqual(Defaults[any].get(), int64)
 		// Test UInt
 		let uint = UInt.max
-		Defaults[any] = uint
-		XCTAssertEqual(Defaults[any], uint)
+		Defaults[any].set(uint)
+		XCTAssertEqual(Defaults[any].get(), uint)
 		// Test UInt8
 		let uint8 = UInt8.max
-		Defaults[any] = uint8
-		XCTAssertEqual(Defaults[any], uint8)
+		Defaults[any].set(uint8)
+		XCTAssertEqual(Defaults[any].get(), uint8)
 		// Test UInt16
 		let uint16 = UInt16.max
-		Defaults[any] = uint16
-		XCTAssertEqual(Defaults[any], uint16)
+		Defaults[any].set(uint16)
+		XCTAssertEqual(Defaults[any].get(), uint16)
 		// Test UInt32
 		let uint32 = UInt32.max
-		Defaults[any] = uint32
-		XCTAssertEqual(Defaults[any], uint32)
+		Defaults[any].set(uint32)
+		XCTAssertEqual(Defaults[any].get(), uint32)
 		// Test UInt64
 		let uint64 = UInt64.max
-		Defaults[any] = uint64
-		XCTAssertEqual(Defaults[any], uint64)
+		Defaults[any].set(uint64)
+		XCTAssertEqual(Defaults[any].get(), uint64)
 		// Test Double
 		Defaults[any] = 12_131.4
 		XCTAssertEqual(Defaults[any], 12_131.4)
 		// Test Bool
 		Defaults[any] = true
-		XCTAssertTrue(Defaults[any, type: Bool.self]!)
+		XCTAssertTrue(Defaults[any].get(Bool.self)!)
 		// Test String
 		Defaults[any] = "121314"
 		XCTAssertEqual(Defaults[any], "121314")
 		// Test Float
-		Defaults[any, type: Float.self] = 12_131.456
-		XCTAssertEqual(Defaults[any, type: Float.self], 12_131.456)
+		Defaults[any].set(12_131.456, type: Float.self)
+		XCTAssertEqual(Defaults[any].get(Float.self), 12_131.456)
 		// Test Date
 		let date = Date()
-		Defaults[any] = date
-		XCTAssertEqual(Defaults[any, type: Date.self], date)
+		Defaults[any].set(date)
+		XCTAssertEqual(Defaults[any].get(Date.self), date)
 		// Test Data
 		let data = "121314".data(using: .utf8)
-		Defaults[any] = data
-		XCTAssertEqual(Defaults[any], data)
+		Defaults[any].set(data)
+		XCTAssertEqual(Defaults[any].get(Data.self), data)
 		// Test Array
 		Defaults[any] = [1, 2, 3]
-		if let array: [Int] = Defaults[any] {
+		if let array: [Int] = Defaults[any].get() {
 			XCTAssertEqual(array[0], 1)
 			XCTAssertEqual(array[1], 2)
 			XCTAssertEqual(array[2], 3)
 		}
 		// Test Dictionary
 		Defaults[any] = ["unicorn": "🦄", "boolean": true, "number": 3]
-		if let dictionary = Defaults[any, type: [String: Defaults.AnySerializable].self] {
+		if let dictionary = Defaults[any].get([String: Defaults.AnySerializable].self) {
 			XCTAssertEqual(dictionary["unicorn"], "🦄")
 			XCTAssertTrue(dictionary["boolean"]!.get(Bool.self)!)
 			XCTAssertEqual(dictionary["number"], 3)
 		}
 		// Test Set
-		Defaults[any] = Set([1])
-		XCTAssertEqual(Defaults[any, type: Set<Int>.self]?.first, 1)
+		Defaults[any].set(Set([1]))
+		XCTAssertEqual(Defaults[any].get(Set<Int>.self)?.first, 1)
 		// Test URL
-		Defaults[any] = URL(string: "https://example.com")!
-		XCTAssertEqual(Defaults[any]!, URL(string: "https://example.com")!)
+		Defaults[any].set(URL(string: "https://example.com")!)
+		XCTAssertEqual(Defaults[any].get()!, URL(string: "https://example.com")!)
 		#if os(macOS)
 		// Test NSColor
-		Defaults[any] = NSColor(red: CGFloat(103) / CGFloat(0xFF), green: CGFloat(132) / CGFloat(0xFF), blue: CGFloat(255) / CGFloat(0xFF), alpha: 0.987)
-		XCTAssertEqual(Defaults[any, type: NSColor.self]?.alphaComponent, 0.987)
+		Defaults[any].set(NSColor(red: CGFloat(103) / CGFloat(0xFF), green: CGFloat(132) / CGFloat(0xFF), blue: CGFloat(255) / CGFloat(0xFF), alpha: 0.987))
+		XCTAssertEqual(Defaults[any].get(NSColor.self)?.alphaComponent, 0.987)
 		#else
 		// Test UIColor
-		Defaults[any] = Defaults.AnySerializable(UIColor(red: CGFloat(103) / CGFloat(0xFF), green: CGFloat(132) / CGFloat(0xFF), blue: CGFloat(255) / CGFloat(0xFF), alpha: 0.654))
-		XCTAssertEqual(Defaults[any, type: UIColor.self]?.cgColor.alpha, 0.654)
+		Defaults[any].set(UIColor(red: CGFloat(103) / CGFloat(0xFF), green: CGFloat(132) / CGFloat(0xFF), blue: CGFloat(255) / CGFloat(0xFF), alpha: 0.654))
+		XCTAssertEqual(Defaults[any].get(UIColor.self)?.cgColor.alpha, 0.654)
 		#endif
 		// Test Codable type
-		Defaults[any] = CodableUnicorn(is_missing: false)
-		XCTAssertFalse(Defaults[any, type: CodableUnicorn.self]!.is_missing)
+		Defaults[any].set(CodableUnicorn(is_missing: false))
+		XCTAssertFalse(Defaults[any].get(CodableUnicorn.self)!.is_missing)
 		// Test Custom type
-		Defaults[any] = Unicorn(is_missing: true)
-		XCTAssertTrue(Defaults[any, type: Unicorn.self]!.is_missing)
+		Defaults[any].set(Unicorn(is_missing: true))
+		XCTAssertTrue(Defaults[any].get(Unicorn.self)!.is_missing)
 		// Test nil
 		Defaults[any] = nil
 		XCTAssertEqual(Defaults[any], 121_314)
@@ -184,8 +191,8 @@ final class DefaultsAnySerializableTests: XCTestCase {
 		XCTAssertNil(Defaults[key])
 		Defaults[key] = 12_131.4
 		XCTAssertEqual(Defaults[key], 12_131.4)
-		Defaults[key] = mime.JSON
-		XCTAssertEqual(Defaults[key, type: mime.self], mime.JSON)
+		Defaults[key]?.set(mime.JSON)
+		XCTAssertEqual(Defaults[key]?.get(mime.self), mime.JSON)
 		Defaults[key] = nil
 		XCTAssertNil(Defaults[key])
 	}

--- a/Tests/DefaultsTests/DefaultsNSColorTests.swift
+++ b/Tests/DefaultsTests/DefaultsNSColorTests.swift
@@ -1,4 +1,3 @@
-#if os(macOS)
 import Foundation
 import Defaults
 import XCTest
@@ -305,4 +304,3 @@ final class DefaultsNSColorTests: XCTestCase {
 		waitForExpectations(timeout: 10)
 	}
 }
-#endif

--- a/Tests/DefaultsTests/DefaultsNSColorTests.swift
+++ b/Tests/DefaultsTests/DefaultsNSColorTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 import Defaults
 import XCTest
@@ -304,3 +305,4 @@ final class DefaultsNSColorTests: XCTestCase {
 		waitForExpectations(timeout: 10)
 	}
 }
+#endif

--- a/readme.md
+++ b/readme.md
@@ -646,7 +646,7 @@ But `Defaults` need its value to conform to `Defaults.Serializable`, so here is 
 
 `Defaults.AnySerializable` only available for `Value` which conforms to `Defaults.Serializable`.
 
-Warn: The type erasure should only be used when there's no other way to handle it. It has much worse performance.
+Warn: The type erasure should only be used when there's no other way to handle it because it has much worse performance. It should only be used in wrapped types. For example, wrapped in `Array`, `Set` or `Dictionary`.
 
 #### Primitive type
 

--- a/readme.md
+++ b/readme.md
@@ -671,13 +671,15 @@ enum mime: String, Defaults.Serializable {
 	case STREAM = "application/octet-stream"
 }
 
-let any = Defaults.Key<[Defaults.AnySerializable]>("anyKey", default: [Defaults.AnySerializable(mime.JSON)])
+let any = Defaults.Key<Defaults.AnySerializable>("anyKey", default: [Defaults.AnySerializable(mime.JSON)])
 
-if let mimeType: mime = Defaults[any][0].get() {
+if let mimeType: mime = Defaults[any].get() {
 	print(mimeType.rawValue) //=> "application/json"
 }
-Defaults[any].append(123)
-print(Defaults[any][1].get(Int.self)) //=> 123
+Defaults[any].set(mime.STREAM)
+if let mimeType: mime = Defaults[any].get() {
+	print(mimeType.rawValue) //=> "application/octet-stream"
+}
 ```
 
 #### Wrapped in `Array`, `Set`, `Dictionary`

--- a/readme.md
+++ b/readme.md
@@ -399,8 +399,8 @@ Type: `class`
 
 Type erasure for `Defaults.Serializable`.
 
-- `get<Value: Defaults.Serializable>() -> Value`: Retrieve the value which type is `Value` from the UserDefaults.
-- `get<Value: Defaults.Serializable>(_: Value.Type) -> Value`: Specific the `Value` you want to retrieve, is useful in some ambiguous cases. 
+- `get<Value: Defaults.Serializable>() -> Value?`: Retrieve the value which type is `Value` from the UserDefaults.
+- `get<Value: Defaults.Serializable>(_: Value.Type) -> Value?`: Specific the `Value` you want to retrieve, is useful in some ambiguous cases. 
 - `set<Value: Defaults.Serializable>(_ newValue: Value)`: Set newValue into `Defaults.AnySerializable`.
 
 #### `Defaults.reset(keys…)`
@@ -657,11 +657,11 @@ let any = Defaults.Key<Defaults.AnySerializable>("anyKey", default: 1)
 Defaults[any] = "🦄"
 ```
 
-#### Custom type
+#### Other types
 
 ##### Using `get`, `set`
 
-For custom type you will have to assign it like this.
+For other types you will have to assign it like this.
 
 ```swift
 enum mime: String, Defaults.Serializable {
@@ -729,8 +729,6 @@ if let mimeType: mime = Defaults[.magic]["enum"]?.get() {
 ```
 
 For more examples, see [Tests/DefaultsAnySerializableTests](./Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift).
-
-
 
 ### Custom `Collection` type
 

--- a/readme.md
+++ b/readme.md
@@ -400,7 +400,7 @@ Type: `class`
 Type-erased wrappers for `Defaults.Serializable` values.
 
 - `get<Value: Defaults.Serializable>() -> Value?`: Retrieve the value which type is `Value` from the UserDefaults.
-- `get<Value: Defaults.Serializable>(_: Value.Type) -> Value?`: Specific the `Value` you want to retrieve, is useful in some ambiguous cases. 
+- `get<Value: Defaults.Serializable>(_: Value.Type) -> Value?`: Specific the `Value` that you want to retrieve, this will be useful in some ambiguous cases. 
 - `set<Value: Defaults.Serializable>(_ newValue: Value)`: Set newValue into `Defaults.AnySerializable`.
 
 #### `Defaults.reset(keys…)`


### PR DESCRIPTION
## Summary

`Defaults.AnySerializable` is a type erasure for `Defaults.Serializable`.
It can accept the value conforms to `Defaults.Serializable`.

## Features

With `Defaults.AnySerializable` user can use `Defaults.Key` dynamically.
User will not need to specialize the type of `Defaults.Key`, just use `Defaults.Key<Defaults.AnySerializable>`.

## Usage

```swift
let any = Defaults.Key<Defaults.AnySerializable>("anyKey", default: 121_314)
let int = Defaults[any].get(Int.self)
Defaults[any].set(value: "🦄")
print(Defaults[any].get(String.self)) //=> "🦄"
```