### PR TITLE
Add `.defaultValue` and `.isDefaultValue` to `@Default`

### DIFF
--- a/Sources/Defaults/SwiftUI.swift
+++ b/Sources/Defaults/SwiftUI.swift
@@ -87,6 +87,9 @@ public struct Default<Value: Defaults.Serializable>: DynamicProperty {
 
 	public var projectedValue: Binding<Value> { $observable.value }
 
+	/// The default value of the key.
+	public var defaultValue: Value { key.defaultValue }
+
 	/// Combine publisher that publishes values when the `Defaults` item changes.
 	public var publisher: Publisher { Defaults.publisher(key) }
 

--- a/Sources/Defaults/SwiftUI.swift
+++ b/Sources/Defaults/SwiftUI.swift
@@ -121,6 +121,12 @@ public struct Default<Value: Defaults.Serializable>: DynamicProperty {
 	}
 }
 
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Default where Value: Equatable {
+	/// Indicates hether the value is the same as the default value.
+	public var isDefaultValue: Bool { wrappedValue == defaultValue }
+}
+
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension Defaults {
 	/**

--- a/Sources/Defaults/SwiftUI.swift
+++ b/Sources/Defaults/SwiftUI.swift
@@ -123,7 +123,7 @@ public struct Default<Value: Defaults.Serializable>: DynamicProperty {
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Default where Value: Equatable {
-	/// Indicates hether the value is the same as the default value.
+	/// Indicates whether the value is the same as the default value.
 	public var isDefaultValue: Bool { wrappedValue == defaultValue }
 }
 

--- a/Tests/DefaultsTests/DefaultsSwiftUITests.swift
+++ b/Tests/DefaultsTests/DefaultsSwiftUITests.swift
@@ -45,5 +45,6 @@ final class DefaultsSwiftUITests: XCTestCase {
 		XCTAssertEqual(view.user.username, "Chen")
 		XCTAssertEqual(view.setInt, Set(1...4))
 		XCTAssertFalse(Default(.hasUnicorn).defaultValue)
+		XCTAssertFalse(Default(.hasUnicorn).isDefaultValue)
 	}
 }

--- a/Tests/DefaultsTests/DefaultsSwiftUITests.swift
+++ b/Tests/DefaultsTests/DefaultsSwiftUITests.swift
@@ -44,5 +44,6 @@ final class DefaultsSwiftUITests: XCTestCase {
 		XCTAssertTrue(view.hasUnicorn)
 		XCTAssertEqual(view.user.username, "Chen")
 		XCTAssertEqual(view.setInt, Set(1...4))
+		XCTAssertFalse(Default(.hasUnicorn).defaultValue)
 	}
 }


### PR DESCRIPTION
I need it to disable an input the value matches the default value. This is what I'm currently using:

```swift
.disabled(textSize == Defaults.Keys.textSize.defaultValue)
```