### PR TITLE
Support types that conform to both `Codable` and `NSSecureCoding`

### DIFF
--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -46,6 +46,13 @@ extension Defaults {
 	public struct RawRepresentableCodableBridge<Value: RawRepresentable & Codable>: CodableBridge {}
 }
 
+/**
+This exists to avoid compiler ambiguity.
+*/
+extension Defaults {
+	public struct CodableNSSecureCodingBridge<Value: Codable & NSSecureCoding>: CodableBridge {}
+}
+
 extension Defaults {
 	public struct URLBridge: CodableBridge {
 		public typealias Value = URL

--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -86,6 +86,10 @@ extension Defaults.Serializable where Self: Codable {
 	public static var bridge: Defaults.TopLevelCodableBridge<Self> { Defaults.TopLevelCodableBridge() }
 }
 
+extension Defaults.Serializable where Self: Codable & NSSecureCoding {
+	public static var bridge: Defaults.CodableNSSecureCodingBridge<Self> { Defaults.CodableNSSecureCodingBridge() }
+}
+
 extension Defaults.Serializable where Self: RawRepresentable {
 	public static var bridge: Defaults.RawRepresentableBridge<Self> { Defaults.RawRepresentableBridge() }
 }

--- a/Tests/DefaultsTests/DefaultsCodableTests.swift
+++ b/Tests/DefaultsTests/DefaultsCodableTests.swift
@@ -8,6 +8,19 @@ private struct Unicorn: Codable, Defaults.Serializable {
 
 private let fixtureCodable = Unicorn(isUnicorn: true)
 
+@objc(UnicornCodableAndNSSecureCoding)
+private final class UnicornCodableAndNSSecureCoding: NSObject, NSSecureCoding, Codable, Defaults.Serializable {
+	static let supportsSecureCoding = true
+
+	func encode(with coder: NSCoder) {}
+
+	init?(coder: NSCoder) {}
+
+	override init() {
+		super.init()
+	}
+}
+
 extension Defaults.Keys {
 	fileprivate static let codable = Key<Unicorn>("codable", default: fixtureCodable)
 	fileprivate static let codableArray = Key<[Unicorn]>("codable", default: [fixtureCodable])
@@ -118,6 +131,11 @@ final class DefaultsCodableTests: XCTestCase {
 		XCTAssertTrue(Defaults[.codableDictionary]["0"]?.isUnicorn ?? false)
 		Defaults[.codableDictionary]["0"] = Unicorn(isUnicorn: false)
 		XCTAssertFalse(Defaults[.codableDictionary]["0"]?.isUnicorn ?? true)
+	}
+
+	func testCodableAndNSSecureCoding() {
+		let fixture = UnicornCodableAndNSSecureCoding()
+		_ = Defaults.Key<UnicornCodableAndNSSecureCoding>("testCodableAndNSSecureCoding", default: fixture)
 	}
 
 	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)

--- a/readme.md
+++ b/readme.md
@@ -80,12 +80,15 @@ Add `https://github.com/sindresorhus/Defaults` in the [â€œSwift Package Managerâ
 - `NSColor` (macOS)
 - `UIColor` (iOS)
 - `Codable`
+- `NSSecureCoding`
 
 Defaults also support the above types wrapped in `Array`, `Set`, `Dictionary`, and even wrapped in nested types. For example, `[[String: Set<[String: Int]>]]`.
 
 For more types, see the [enum example](#enum-example), [`Codable` example](#codable-example), or [advanced Usage](#advanced-usage). For more examples, see [Tests/DefaultsTests](./Tests/DefaultsTests).
 
 You can easily add support for any custom type.
+
+If a type conforms to both `NSSecureCoding` and `Codable`, then `Codable` will be used for the serialization.
 
 ## Usage
 


### PR DESCRIPTION
In my app, I already had `NSColor` conforming to `Codable`, which caused a compiler ambiguity, since it already conforms to `NSSecureCoding`.

@hank121314 It would be nice if a user could somehow choose whether to use the `Codable` or `NSSecureCoding` for the serialization.