### PR TITLE
Add support to not use `Codable`

### DIFF
--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -118,7 +118,6 @@ extension Optional: Defaults.Serializable where Wrapped: Defaults.Serializable {
 }
 
 extension Defaults.CollectionSerializable where Element: Defaults.Serializable {
-	public static var isCollectionType: Bool { true }
 	public static var bridge: Defaults.CollectionBridge<Self> { Defaults.CollectionBridge() }
 }
 

--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -10,6 +10,16 @@ extension Defaults.Serializable {
 	public static var isNativelySupportedType: Bool { false }
 }
 
+extension Defaults.Bridge {
+	public func serialize(_ value: Value?, usingCodable: Bool) -> Serializable? {
+		serialize(value)
+	}
+
+	public func deserialize(_ object: Serializable?, usingCodable: Bool) -> Value? {
+		deserialize(object)
+	}
+}
+
 extension Data: Defaults.Serializable {
 	public static let isNativelySupportedType = true
 }
@@ -79,23 +89,23 @@ extension UInt64: Defaults.Serializable {
 }
 
 extension URL: Defaults.Serializable {
-	public static let bridge = Defaults.URLBridge()
+	public static var bridge: Defaults.TopLevelCodableBridge<URL> { Defaults.TopLevelCodableBridge() }
 }
 
 extension Defaults.Serializable where Self: Codable {
 	public static var bridge: Defaults.TopLevelCodableBridge<Self> { Defaults.TopLevelCodableBridge() }
 }
 
+extension Defaults.Serializable where Self: RawRepresentable & Codable {
+	public static var bridge: Defaults.AmbiguousCodableBrigde<Self, Defaults.RawRepresentableBridge<Self>> { Defaults.AmbiguousCodableBrigde(bridge: Defaults.RawRepresentableBridge()) }
+}
+
 extension Defaults.Serializable where Self: Codable & NSSecureCoding {
-	public static var bridge: Defaults.CodableNSSecureCodingBridge<Self> { Defaults.CodableNSSecureCodingBridge() }
+	public static var bridge: Defaults.AmbiguousCodableBrigde<Self, Defaults.NSSecureCodingBridge<Self>> { Defaults.AmbiguousCodableBrigde(bridge: Defaults.NSSecureCodingBridge()) }
 }
 
 extension Defaults.Serializable where Self: RawRepresentable {
 	public static var bridge: Defaults.RawRepresentableBridge<Self> { Defaults.RawRepresentableBridge() }
-}
-
-extension Defaults.Serializable where Self: RawRepresentable & Codable {
-	public static var bridge: Defaults.RawRepresentableCodableBridge<Self> { Defaults.RawRepresentableCodableBridge() }
 }
 
 extension Defaults.Serializable where Self: NSSecureCoding {
@@ -108,6 +118,7 @@ extension Optional: Defaults.Serializable where Wrapped: Defaults.Serializable {
 }
 
 extension Defaults.CollectionSerializable where Element: Defaults.Serializable {
+	public static var isCollectionType: Bool { true }
 	public static var bridge: Defaults.CollectionBridge<Self> { Defaults.CollectionBridge() }
 }
 

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -86,6 +86,8 @@ public protocol DefaultsBridge {
 
 	func serialize(_ value: Value?) -> Serializable?
 	func deserialize(_ object: Serializable?) -> Value?
+	func serialize(_ value: Value?, usingCodable: Bool) -> Serializable?
+	func deserialize(_ object: Serializable?, usingCodable: Bool) -> Value?
 }
 
 public protocol DefaultsCollectionSerializable: Collection, Defaults.Serializable {
@@ -97,6 +99,3 @@ public protocol DefaultsSetAlgebraSerializable: SetAlgebra, Defaults.Serializabl
 	/// Since `SetAlgebra` protocol does not conform to `Sequence`, we cannot convert a `SetAlgebra` to an `Array` directly.
 	func toArray() -> [Element]
 }
-
-/// Convenience protocol for `Codable`.
-public protocol DefaultsCodableBridge: Defaults.Bridge where Serializable == String, Value: Codable {}

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -42,6 +42,7 @@ public enum Defaults {
 		/// The `default` parameter can be left out if the `Value` type is an optional.
 		public init(_ key: String, default defaultValue: Value, suite: UserDefaults = .standard, usingCodable: Bool = true) {
 			self.defaultValue = defaultValue
+
 			super.init(name: key, suite: suite)
 
 			if (defaultValue as? _DefaultsOptionalType)?.isNil == true {

--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -98,6 +98,17 @@ extension Defaults {
 		return AnyPublisher(publisher)
 	}
 
+	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)
+	public static func publisher<Value: Serializable & Codable>(
+		_ key: Key<Value>,
+		options: ObservationOptions = [.initial]
+	) -> AnyPublisher<KeyChange<Value>, Never> {
+		let publisher = DefaultsPublisher(suite: key.suite, key: key.name, options: options)
+			.map { KeyChange<Value>(change: $0, defaultValue: key.defaultValue, usingCodable: key.usingCodable) }
+
+		return AnyPublisher(publisher)
+	}
+
 	/**
 	Publisher for multiple `Key<T>` observation, but without specific information about changes.
 	*/

--- a/Sources/Defaults/UserDefaults.swift
+++ b/Sources/Defaults/UserDefaults.swift
@@ -9,7 +9,15 @@ extension UserDefaults {
 		return Value.toValue(anyObject)
 	}
 
-	 func _set<Value: Defaults.Serializable>(_ key: String, to value: Value) {
+	func _get<Value: Defaults.Serializable & Codable>(_ key: String, usingCodable: Bool) -> Value? {
+		guard let anyObject = object(forKey: key) else {
+			return nil
+		}
+
+		return Value.toCodableValue(anyObject, usingCodable: usingCodable)
+	}
+
+	func _set<Value: Defaults.Serializable>(_ key: String, to value: Value) {
 		if (value as? _DefaultsOptionalType)?.isNil == true {
 			removeObject(forKey: key)
 			return
@@ -18,10 +26,26 @@ extension UserDefaults {
 		set(Value.toSerializable(value), forKey: key)
 	}
 
+	func _set<Value: Defaults.Serializable & Codable>(_ key: String, to value: Value, usingCodable: Bool) {
+		if (value as? _DefaultsOptionalType)?.isNil == true {
+			removeObject(forKey: key)
+			return
+		}
+
+		set(Value.toCodableSerializable(value, usingCodable: usingCodable), forKey: key)
+	}
+
 	public subscript<Value: Defaults.Serializable>(key: Defaults.Key<Value>) -> Value {
 		get { _get(key.name) ?? key.defaultValue }
 		set {
 			_set(key.name, to: newValue)
+		}
+	}
+
+	public subscript<Value: Defaults.Serializable & Codable>(key: Defaults.Key<Value>) -> Value {
+		get { _get(key.name, usingCodable: key.usingCodable) ?? key.defaultValue }
+		set {
+			_set(key.name, to: newValue, usingCodable: key.usingCodable)
 		}
 	}
 }

--- a/Tests/DefaultsTests/DefaultsCodableEnumTests.swift
+++ b/Tests/DefaultsTests/DefaultsCodableEnumTests.swift
@@ -8,6 +8,11 @@ private enum FixtureCodableEnum: String, Defaults.Serializable & Codable & Hasha
 	case oneHour = "1 Hour"
 }
 
+private enum Foo: Int, CaseIterable, Codable, Defaults.Serializable {
+	case zero
+	case one
+}
+
 extension Defaults.Keys {
 	fileprivate static let codableEnum = Key<FixtureCodableEnum>("codable_enum", default: .oneHour)
 	fileprivate static let codableEnumArray = Key<[FixtureCodableEnum]>("codable_enum", default: [.oneHour])
@@ -116,6 +121,26 @@ final class DefaultsCodableEnumTests: XCTestCase {
 		Defaults[.codableEnumDictionary]["1"] = .halfHour
 		XCTAssertEqual(Defaults[.codableEnumDictionary]["0"], .oneHour)
 		XCTAssertEqual(Defaults[.codableEnumDictionary]["1"], .halfHour)
+	}
+
+	func testCodableEnumWithUsingCodable() {
+		let fixture = Foo.zero
+		let keyName = "testCodableEnumWithUsingCodable"
+		let key = Defaults.Key<Foo>(keyName, default: fixture, usingCodable: true)
+		XCTAssertNotNil(UserDefaults.standard.string(forKey: keyName))
+		let next = Foo.one
+		Defaults[key] = next
+		XCTAssertEqual(Defaults[key], next)
+	}
+
+	func testCodableEnumWithoutUsingCodable() {
+		let fixture = Foo.zero
+		let keyName = "testCodableEnumWithoutUsingCodable"
+		let key = Defaults.Key<Foo>(keyName, default: fixture, usingCodable: false)
+		XCTAssertNotNil(UserDefaults.standard.integer(forKey: keyName))
+		let next = Foo.one
+		Defaults[key] = next
+		XCTAssertEqual(Defaults[key], next)
 	}
 
 	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)

--- a/readme.md
+++ b/readme.md
@@ -789,6 +789,26 @@ if let mimeType: mime = Defaults[.magic]["enum"]?.get() {
 
 For more examples, see [Tests/DefaultsAnySerializableTests](./Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift).
 
+### Serialization for ambiguous `Codable` type
+
+Sometimes we might have some type that conforms to `Codable & NSSecureCoding` or a `Codable` enum.  
+By default, `Default` will serialize it into a JSON string.  
+If you still want to serialize it as a NSSecure data or a native enum. You can set `usingCodable` to false.  
+
+```swift
+enum mime: String, Defaults.Serializable, Codable {
+	case JSON = "application/json"
+}
+
+extension Defaults.Keys {
+	static let magic = Key<[String: Defaults.AnySerializable]>("magic", default: [:], usingCodable: false)
+}
+
+print(UserDefaults.standard.string(forKey: "magic")) //=> application/json
+```
+
+For more examples, see [Tests/DefaultsCodableTests](./Tests/DefaultsTests/DefaultsCodableTests.swift).
+
 ### Custom `Collection` type
 
 1. Create your `Collection` and make its elements conform to `Defaults.Serializable`.


### PR DESCRIPTION
## Summary

This PR fixed: #79.
I have added a `usingCodable` property to `Defaults.Key`.
If users set `usingCodable` to false, so the serialization will not use `Codable`.

## Usage

```swift
private enum Foo: Int, CaseIterable, Codable, Defaults.Serializable {
	case zero
	case one
}

let key = Defaults.Key<Foo>(keyName, default: fixture, usingCodable: false)
```