### PR TITLE
Add `PreferBridge` protocol for ambiguous serialization.

### DIFF
--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -90,14 +90,21 @@ extension Defaults.Serializable where Self: Codable & NSSecureCoding {
 	public static var bridge: Defaults.CodableNSSecureCodingBridge<Self> { Defaults.CodableNSSecureCodingBridge() }
 }
 
-extension Defaults.Serializable where Self: RawRepresentable {
-	public static var bridge: Defaults.RawRepresentableBridge<Self> { Defaults.RawRepresentableBridge() }
+extension Defaults.Serializable where Self: Codable & NSSecureCoding & Defaults.PreferNSSecureCoding {
+	public static var bridge: Defaults.NSSecureCodingBridge<Self> { Defaults.NSSecureCodingBridge() }
 }
 
-extension Defaults.Serializable where Self: RawRepresentable & Codable {
+extension Defaults.Serializable where Self: Codable & RawRepresentable {
 	public static var bridge: Defaults.RawRepresentableCodableBridge<Self> { Defaults.RawRepresentableCodableBridge() }
 }
 
+extension Defaults.Serializable where Self: Codable & RawRepresentable & Defaults.PreferRawRepresentable {
+	public static var bridge: Defaults.RawRepresentableBridge<Self> { Defaults.RawRepresentableBridge() }
+}
+
+extension Defaults.Serializable where Self: RawRepresentable {
+	public static var bridge: Defaults.RawRepresentableBridge<Self> { Defaults.RawRepresentableBridge() }
+}
 extension Defaults.Serializable where Self: NSSecureCoding {
 	public static var bridge: Defaults.NSSecureCodingBridge<Self> { Defaults.NSSecureCodingBridge() }
 }

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -100,3 +100,22 @@ public protocol DefaultsSetAlgebraSerializable: SetAlgebra, Defaults.Serializabl
 
 /// Convenience protocol for `Codable`.
 public protocol DefaultsCodableBridge: Defaults.Bridge where Serializable == String, Value: Codable {}
+
+/**
+An ambiguous bridge selector protocol.
+
+Let users select theirs preferred bridge when we have the ambiguous bridge.
+
+For example:
+```
+enum Interval: Int, Defaults.Serializable, Codable, Defaults.PreferRawRepresentable {
+ case tenMinutes = 10
+ case halfHour = 30
+ case oneHour = 60
+}
+```
+By default, If an `enum` conforms to `Codable` and `Defaults.Serializable`, it will go to `CodableBridge`.
+But with `Defaults.PreferRawRepresentable` we can switch the bridge back to `RawRepresentableBridge`.
+ */
+public protocol DefaultsPreferRawRepresentable: RawRepresentable {}
+public protocol DefaultsPreferNSSecureCoding: NSSecureCoding {}

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -19,6 +19,8 @@ public enum Defaults {
 	public typealias Serializable = DefaultsSerializable
 	public typealias CollectionSerializable = DefaultsCollectionSerializable
 	public typealias SetAlgebraSerializable = DefaultsSetAlgebraSerializable
+	public typealias PreferRawRepresentable = DefaultsPreferRawRepresentable
+	public typealias PreferNSSecureCoding = DefaultsPreferNSSecureCoding
 	public typealias Bridge = DefaultsBridge
 	typealias CodableBridge = DefaultsCodableBridge
 

--- a/Tests/DefaultsTests/DefaultsCodableEnumTests.swift
+++ b/Tests/DefaultsTests/DefaultsCodableEnumTests.swift
@@ -8,6 +8,12 @@ private enum FixtureCodableEnum: String, Defaults.Serializable & Codable & Hasha
 	case oneHour = "1 Hour"
 }
 
+private enum FixtureCodableEnumPreferRawRepresentable: Int, Defaults.Serializable & Codable & Hashable & Defaults.PreferRawRepresentable {
+	case tenMinutes = 10
+	case halfHour = 30
+	case oneHour = 60
+}
+
 extension Defaults.Keys {
 	fileprivate static let codableEnum = Key<FixtureCodableEnum>("codable_enum", default: .oneHour)
 	fileprivate static let codableEnumArray = Key<[FixtureCodableEnum]>("codable_enum", default: [.oneHour])
@@ -116,6 +122,13 @@ final class DefaultsCodableEnumTests: XCTestCase {
 		Defaults[.codableEnumDictionary]["1"] = .halfHour
 		XCTAssertEqual(Defaults[.codableEnumDictionary]["0"], .oneHour)
 		XCTAssertEqual(Defaults[.codableEnumDictionary]["1"], .halfHour)
+	}
+
+	func testFixtureCodableEnumPreferRawRepresentable() {
+		let fixture: FixtureCodableEnumPreferRawRepresentable = .tenMinutes
+		let keyName = "testFixtureCodableEnumPreferRawRepresentable"
+		_ = Defaults.Key<FixtureCodableEnumPreferRawRepresentable>(keyName, default: fixture)
+		XCTAssertNotNil(UserDefaults.standard.integer(forKey: keyName))
 	}
 
 	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)

--- a/Tests/DefaultsTests/DefaultsCodableTests.swift
+++ b/Tests/DefaultsTests/DefaultsCodableTests.swift
@@ -21,6 +21,19 @@ private final class UnicornCodableAndNSSecureCoding: NSObject, NSSecureCoding, C
 	}
 }
 
+@objc(UnicornCodableAndPreferNSSecureCoding)
+private final class UnicornCodableAndPreferNSSecureCoding: NSObject, NSSecureCoding, Codable, Defaults.Serializable, Defaults.PreferNSSecureCoding {
+	static let supportsSecureCoding = true
+
+	func encode(with coder: NSCoder) {}
+
+	init?(coder: NSCoder) {}
+
+	override init() {
+		super.init()
+	}
+}
+
 extension Defaults.Keys {
 	fileprivate static let codable = Key<Unicorn>("codable", default: fixtureCodable)
 	fileprivate static let codableArray = Key<[Unicorn]>("codable", default: [fixtureCodable])
@@ -135,7 +148,18 @@ final class DefaultsCodableTests: XCTestCase {
 
 	func testCodableAndNSSecureCoding() {
 		let fixture = UnicornCodableAndNSSecureCoding()
-		_ = Defaults.Key<UnicornCodableAndNSSecureCoding>("testCodableAndNSSecureCoding", default: fixture)
+		let keyName = "testCodableAndNSSecureCoding"
+		_ = Defaults.Key<UnicornCodableAndNSSecureCoding>(keyName, default: fixture)
+		XCTAssertNil(UserDefaults.standard.data(forKey: keyName))
+		XCTAssertNotNil(UserDefaults.standard.string(forKey: keyName))
+	}
+
+	func testCodableAndPreferNSSecureCoding() {
+		let fixture = UnicornCodableAndPreferNSSecureCoding()
+		let keyName = "testCodableAndPreferNSSecureCoding"
+		_ = Defaults.Key<UnicornCodableAndPreferNSSecureCoding>(keyName, default: fixture)
+		XCTAssertNil(UserDefaults.standard.string(forKey: keyName))
+		XCTAssertNotNil(UserDefaults.standard.data(forKey: keyName))
 	}
 
 	@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, iOSApplicationExtension 13.0, macOSApplicationExtension 10.15, tvOSApplicationExtension 13.0, watchOSApplicationExtension 6.0, *)

--- a/readme.md
+++ b/readme.md
@@ -789,6 +789,25 @@ if let mimeType: mime = Defaults[.magic]["enum"]?.get() {
 
 For more examples, see [Tests/DefaultsAnySerializableTests](./Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift).
 
+### Serialization for ambiguous Codable type
+
+Sometimes we might have some type that conforms to `Codable & NSSecureCoding` or a `Codable` enum.  
+By default, Defaults will serialize it into a JSON string.  
+If you still want to serialize it as a NSSecure data or a native enum.  
+You can let your type conforms to these [PreferBridge](./Sources/Defaults/Defaults+Protocol.swift#L120) protocol.  
+
+```swift
+enum mime: String, Defaults.Serializable, Codable, Defaults.PreferRawRepresentable {
+	case JSON = "application/json"
+}
+
+extension Defaults.Keys {
+	static let magic = Key<[String: Defaults.AnySerializable]>("magic", default: [:])
+}
+
+print(UserDefaults.standard.string(forKey: "magic")) //=> application/json
+```
+
 ### Custom `Collection` type
 
 1. Create your `Collection` and make its elements conform to `Defaults.Serializable`.


### PR DESCRIPTION
## Summary

This PR fixed: #79.
Add two protocol `Defaults.PreferRawRepresentable` and `Defaults.PreferNSSecureCoding`.
These protocols are in order to let user conveniently force their serialization.

## Usage

```swift
private enum Foo: Int, Defaults.Serializable & Codable & Defaults.PreferRawRepresentable {
	case tenMinutes = 10
	case halfHour = 30
	case oneHour = 60
}
```

Thanks for your code review 😄 !