### PR TITLE
feat(Defaults+Bridge): public some bridge initializer to enable workaround

### DIFF
--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -37,21 +37,30 @@ extension Defaults.CodableBridge {
 Any `Value` that conforms to `Codable` and `Defaults.Serializable` will use `CodableBridge` to do the serialization and deserialization.
 */
 extension Defaults {
-	public struct TopLevelCodableBridge<Value: Codable>: CodableBridge {}
+	public struct TopLevelCodableBridge<Value: Codable>: CodableBridge {
+		// TODO: A temporary workaround for Xcode 13.3 compiler issue. Should remove after https://bugs.swift.org/browse/SR-15807 is fixed.
+		public init() {}
+	}
 }
 
 /**
 `RawRepresentableCodableBridge` is needed because, for example, with `enum SomeEnum: String, Codable, Defaults.Serializable`, the compiler will be confused between `RawRepresentableBridge` and `TopLevelCodableBridge`.
 */
 extension Defaults {
-	public struct RawRepresentableCodableBridge<Value: RawRepresentable & Codable>: CodableBridge {}
+	public struct RawRepresentableCodableBridge<Value: RawRepresentable & Codable>: CodableBridge {
+		// TODO: A temporary workaround for Xcode 13.3 compiler issue. Should remove after https://bugs.swift.org/browse/SR-15807 is fixed.
+		public init() {}
+	}
 }
 
 /**
 This exists to avoid compiler ambiguity.
 */
 extension Defaults {
-	public struct CodableNSSecureCodingBridge<Value: Codable & NSSecureCoding>: CodableBridge {}
+	public struct CodableNSSecureCodingBridge<Value: Codable & NSSecureCoding>: CodableBridge {
+		// TODO: A temporary workaround for Xcode 13.3 compiler issue. Should remove after https://bugs.swift.org/browse/SR-15807 is fixed.
+		public init() {}
+	}
 }
 
 extension Defaults {
@@ -64,6 +73,9 @@ extension Defaults {
 	public struct RawRepresentableBridge<Value: RawRepresentable>: Bridge {
 		public typealias Value = Value
 		public typealias Serializable = Value.RawValue
+
+		// TODO: A temporary workaround for Xcode 13.3 compiler issue. Should remove after https://bugs.swift.org/browse/SR-15807 is fixed.
+		public init() {}
 
 		public func serialize(_ value: Value?) -> Serializable? {
 			value?.rawValue
@@ -83,6 +95,9 @@ extension Defaults {
 	public struct NSSecureCodingBridge<Value: NSSecureCoding>: Bridge {
 		public typealias Value = Value
 		public typealias Serializable = Data
+        
+		// TODO: A temporary workaround for Xcode 13.3 compiler issue. Should remove after https://bugs.swift.org/browse/SR-15807 is fixed.
+		public init() {}
 
 		public func serialize(_ value: Value?) -> Serializable? {
 			guard let object = value else {
@@ -225,6 +240,9 @@ extension Defaults {
 		public typealias Element = Value.Element
 		public typealias Serializable = Any
 
+		// TODO: A temporary workaround for Xcode 13.3 compiler issue. Should remove after https://bugs.swift.org/browse/SR-15807 is fixed.
+		public init() {}
+
 		public func serialize(_ value: Value?) -> Serializable? {
 			guard let setAlgebra = value else {
 				return nil
@@ -263,6 +281,9 @@ extension Defaults {
 		public typealias Value = Value
 		public typealias Element = Value.Element
 		public typealias Serializable = Any
+
+		// TODO: A temporary workaround for Xcode 13.3 compiler issue. Should remove after https://bugs.swift.org/browse/SR-15807 is fixed.
+		public init() {}
 
 		public func serialize(_ value: Value?) -> Serializable? {
 			guard let collection = value else {

--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -95,7 +95,7 @@ extension Defaults {
 	public struct NSSecureCodingBridge<Value: NSSecureCoding>: Bridge {
 		public typealias Value = Value
 		public typealias Serializable = Data
-        
+
 		// TODO: A temporary workaround for Xcode 13.3 compiler issue. Should remove after https://bugs.swift.org/browse/SR-15807 is fixed.
 		public init() {}
 

--- a/Tests/DefaultsTests/DefaultsTests+Workaround.swift
+++ b/Tests/DefaultsTests/DefaultsTests+Workaround.swift
@@ -1,0 +1,38 @@
+// TODO: A temporary workaround for Xcode 13.3 compiler issue. Should remove after https://bugs.swift.org/browse/SR-15807 is fixed.
+import Defaults
+import Foundation
+
+extension Defaults.Serializable where Self: Codable {
+	public static var bridge: Defaults.TopLevelCodableBridge<Self> { Defaults.TopLevelCodableBridge() }
+}
+
+extension Defaults.Serializable where Self: Codable & NSSecureCoding {
+	public static var bridge: Defaults.CodableNSSecureCodingBridge<Self> { Defaults.CodableNSSecureCodingBridge() }
+}
+
+extension Defaults.Serializable where Self: Codable & NSSecureCoding & Defaults.PreferNSSecureCoding {
+	public static var bridge: Defaults.NSSecureCodingBridge<Self> { Defaults.NSSecureCodingBridge() }
+}
+
+extension Defaults.Serializable where Self: Codable & RawRepresentable {
+	public static var bridge: Defaults.RawRepresentableCodableBridge<Self> { Defaults.RawRepresentableCodableBridge() }
+}
+
+extension Defaults.Serializable where Self: Codable & RawRepresentable & Defaults.PreferRawRepresentable {
+	public static var bridge: Defaults.RawRepresentableBridge<Self> { Defaults.RawRepresentableBridge() }
+}
+
+extension Defaults.Serializable where Self: RawRepresentable {
+	public static var bridge: Defaults.RawRepresentableBridge<Self> { Defaults.RawRepresentableBridge() }
+}
+extension Defaults.Serializable where Self: NSSecureCoding {
+	public static var bridge: Defaults.NSSecureCodingBridge<Self> { Defaults.NSSecureCodingBridge() }
+}
+
+extension Defaults.CollectionSerializable where Element: Defaults.Serializable {
+	public static var bridge: Defaults.CollectionBridge<Self> { Defaults.CollectionBridge() }
+}
+
+extension Defaults.SetAlgebraSerializable where Element: Defaults.Serializable & Hashable {
+	public static var bridge: Defaults.SetAlgebraBridge<Self> { Defaults.SetAlgebraBridge() }
+}

--- a/readme.md
+++ b/readme.md
@@ -951,6 +951,12 @@ Defaults[.stringSet].contains("Hello") //=> true
 Defaults[.stringSet].contains("World!") //=> true
 ```
 
+## TroubleShooting
+
+### Cannot use `Defaults` in Xcode 13.3.
+
+Please refer to [workaround.md](./workaround.md).
+
 ## FAQ
 
 ### How can I store a dictionary of arbitrary values?

--- a/workaround.md
+++ b/workaround.md
@@ -1,0 +1,50 @@
+## Workaround For Xcode 13.3
+
+When using `Defaults` with Xcode 13.3 the compiler might complain about `Type 'YourType' does not conform to protocol 'DefaultsSerializable'`.  
+
+Try the step below:
+
+1. Create `Defaults+Workaround.swift` in the module which is using `Defaults`.
+2. Copy the codes below into `Defaults+Workaround.swift`
+
+```swift
+import Defaults
+import Foundation
+
+extension Defaults.Serializable where Self: Codable {
+	public static var bridge: Defaults.TopLevelCodableBridge<Self> { Defaults.TopLevelCodableBridge() }
+}
+
+extension Defaults.Serializable where Self: Codable & NSSecureCoding {
+	public static var bridge: Defaults.CodableNSSecureCodingBridge<Self> { Defaults.CodableNSSecureCodingBridge() }
+}
+
+extension Defaults.Serializable where Self: Codable & NSSecureCoding & Defaults.PreferNSSecureCoding {
+	public static var bridge: Defaults.NSSecureCodingBridge<Self> { Defaults.NSSecureCodingBridge() }
+}
+
+extension Defaults.Serializable where Self: Codable & RawRepresentable {
+	public static var bridge: Defaults.RawRepresentableCodableBridge<Self> { Defaults.RawRepresentableCodableBridge() }
+}
+
+extension Defaults.Serializable where Self: Codable & RawRepresentable & Defaults.PreferRawRepresentable {
+	public static var bridge: Defaults.RawRepresentableBridge<Self> { Defaults.RawRepresentableBridge() }
+}
+
+extension Defaults.Serializable where Self: RawRepresentable {
+	public static var bridge: Defaults.RawRepresentableBridge<Self> { Defaults.RawRepresentableBridge() }
+}
+extension Defaults.Serializable where Self: NSSecureCoding {
+	public static var bridge: Defaults.NSSecureCodingBridge<Self> { Defaults.NSSecureCodingBridge() }
+}
+
+extension Defaults.CollectionSerializable where Element: Defaults.Serializable {
+	public static var bridge: Defaults.CollectionBridge<Self> { Defaults.CollectionBridge() }
+}
+
+extension Defaults.SetAlgebraSerializable where Element: Defaults.Serializable & Hashable {
+	public static var bridge: Defaults.SetAlgebraBridge<Self> { Defaults.SetAlgebraBridge() }
+}
+```
+
+This issue is caused by swift compiler. After [SR-15807](https://bugs.swift.org/browse/SR-15807) is fixed this workaround might not be needed.


### PR DESCRIPTION
## Summary

Workaround for #93.

- Add `DefaultsTests+workaround.swift` in Tests to pass test cases.
- Add some documents about Xcode 13.3 workaround.

Thanks for your code review 😄 !