### PR TITLE
Add support for `ClosedRange` and `Range`

### DIFF
--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -347,6 +347,7 @@ extension Defaults {
 			guard let value = value else {
 				return nil
 			}
+
 			if Bound.isNativelySupportedType {
 				return [value.lowerBound, value.upperBound]
 			}
@@ -365,6 +366,7 @@ extension Defaults {
 			guard let object = object else {
 				return nil
 			}
+
 			if Bound.isNativelySupportedType {
 				guard
 					let lowerBound = object[safe: 0] as? Bound,

--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -146,6 +146,14 @@ extension Color: Defaults.Serializable {
 	public static let bridge = Defaults.ColorBridge()
 }
 
+extension Range: Defaults.RangeSerializable where Bound: Defaults.Serializable {
+	public static var bridge: Defaults.RangeBridge<Range> { Defaults.RangeBridge() }
+}
+
+extension ClosedRange: Defaults.RangeSerializable where Bound: Defaults.Serializable {
+	public static var bridge: Defaults.RangeBridge<ClosedRange> { Defaults.RangeBridge() }
+}
+
 #if os(macOS)
 /**
 `NSColor` conforms to `NSSecureCoding`, so it goes to `NSSecureCodingBridge`.

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -131,7 +131,7 @@ public protocol DefaultsPreferNSSecureCoding: NSSecureCoding {}
 
 // Essential properties for serializing and deserializing `ClosedRange` and `Range`.
 public protocol DefaultsRange {
-	associatedtype Bound: Defaults.Serializable, Comparable
+	associatedtype Bound: Comparable, Defaults.Serializable
 
 	var lowerBound: Bound { get }
 	var upperBound: Bound { get }

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -128,3 +128,13 @@ By default, if an `enum` conforms to `Codable` and `Defaults.Serializable`, it w
 */
 public protocol DefaultsPreferRawRepresentable: RawRepresentable {}
 public protocol DefaultsPreferNSSecureCoding: NSSecureCoding {}
+
+// Essential properties for serializing and deserializing `ClosedRange` and `Range`.
+public protocol DefaultsRange {
+	associatedtype Bound: Defaults.Serializable, Comparable
+
+	var lowerBound: Bound { get }
+	var upperBound: Bound { get }
+
+	init(uncheckedBounds: (lower: Bound, upper: Bound))
+}

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -24,6 +24,7 @@ public enum Defaults {
 	public typealias PreferRawRepresentable = DefaultsPreferRawRepresentable
 	public typealias PreferNSSecureCoding = DefaultsPreferNSSecureCoding
 	public typealias Bridge = DefaultsBridge
+	public typealias RangeSerializable = DefaultsRange & DefaultsSerializable
 	typealias CodableBridge = DefaultsCodableBridge
 
 	// We cannot use `Key` as the container for keys because of "Static stored properties not supported in generic types".

--- a/Sources/Defaults/Utilities.swift
+++ b/Sources/Defaults/Utilities.swift
@@ -160,6 +160,12 @@ extension Sequence {
 	}
 }
 
+extension Collection {
+	subscript(safe index: Index) -> Element? {
+		indices.contains(index) ? self[index] : nil
+	}
+}
+
 
 extension Defaults.Serializable {
 	/**

--- a/Tests/DefaultsTests/DefaultsRangeTests.swift
+++ b/Tests/DefaultsTests/DefaultsRangeTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import Defaults
+import XCTest
+
+private struct Date {
+	let year: Int
+	let month: Int
+	let day: Int
+}
+
+extension Date: Defaults.Serializable {
+	public struct DateBridge: Defaults.Bridge {
+		public typealias Value = Date
+		public typealias Serializable = [Int]
+
+		public func serialize(_ value: Value?) -> Serializable? {
+			guard let value = value else {
+				return nil
+			}
+
+			return [value.year, value.month, value.day]
+		}
+
+		public func deserialize(_ object: Serializable?) -> Value? {
+			guard let object = object else {
+				return nil
+			}
+
+			return .init(year: object[0], month: object[1], day: object[2])
+		}
+	}
+
+	public static let bridge = DateBridge()
+}
+
+extension Date: Comparable {
+	static func < (lhs: Date, rhs: Date) -> Bool {
+		if lhs.year != rhs.year {
+				return lhs.year < rhs.year
+		} else if lhs.month != rhs.month {
+				return lhs.month < rhs.month
+		} else {
+				return lhs.day < rhs.day
+		}
+	}
+
+	static func == (lhs: Date, rhs: Date) -> Bool {
+		lhs.year == rhs.year && lhs.month == rhs.month
+				&& lhs.day == rhs.day
+	}
+}
+
+// Fixtures:
+private let fixtureRange = 0..<10
+private let nextFixtureRange = 1..<20
+private let fixtureDateRange = Date(year: 2022, month: 4, day: 0)..<Date(year: 2022, month: 5, day: 0)
+private let nextFixtureDateRange = Date(year: 2022, month: 6, day: 1)..<Date(year: 2022, month: 7, day: 1)
+private let fixtureClosedRange = 0...10
+private let nextFixtureClosedRange = 1...20
+private let fixtureDateClosedRange = Date(year: 2022, month: 4, day: 0)...Date(year: 2022, month: 5, day: 0)
+private let nextFixtureDateClosedRange = Date(year: 2022, month: 6, day: 1)...Date(year: 2022, month: 7, day: 1)
+
+final class DefaultsClosedRangeTests: XCTestCase {
+	override func setUp() {
+		super.setUp()
+		Defaults.removeAll()
+	}
+
+	override func tearDown() {
+		super.tearDown()
+		Defaults.removeAll()
+	}
+
+	func testKey() {
+		// Test native support Range type
+		let key = Defaults.Key<Range>("independentRangeKey", default: fixtureRange)
+		XCTAssertEqual(fixtureRange.upperBound, Defaults[key].upperBound)
+		XCTAssertEqual(fixtureRange.lowerBound, Defaults[key].lowerBound)
+		Defaults[key] = nextFixtureRange
+		XCTAssertEqual(nextFixtureRange.upperBound, Defaults[key].upperBound)
+		XCTAssertEqual(nextFixtureRange.lowerBound, Defaults[key].lowerBound)
+
+		// Test serializable Range type
+		let dateKey = Defaults.Key<Range<Date>>("independentRangeDateKey", default: fixtureDateRange)
+		XCTAssertEqual(fixtureDateRange.upperBound, Defaults[dateKey].upperBound)
+		XCTAssertEqual(fixtureDateRange.lowerBound, Defaults[dateKey].lowerBound)
+		Defaults[dateKey] = nextFixtureDateRange
+		XCTAssertEqual(nextFixtureDateRange.upperBound, Defaults[dateKey].upperBound)
+		XCTAssertEqual(nextFixtureDateRange.lowerBound, Defaults[dateKey].lowerBound)
+
+		// Test native support ClosedRange type
+		let closedKey = Defaults.Key<ClosedRange>("independentClosedRangeKey", default: fixtureClosedRange)
+		XCTAssertEqual(fixtureClosedRange.upperBound, Defaults[closedKey].upperBound)
+		XCTAssertEqual(fixtureClosedRange.lowerBound, Defaults[closedKey].lowerBound)
+		Defaults[closedKey] = nextFixtureClosedRange
+		XCTAssertEqual(nextFixtureClosedRange.upperBound, Defaults[closedKey].upperBound)
+		XCTAssertEqual(nextFixtureClosedRange.lowerBound, Defaults[closedKey].lowerBound)
+
+		// Test serializable ClosedRange type
+		let closedDateKey = Defaults.Key<ClosedRange<Date>>("independentClosedRangeDateKey", default: fixtureDateClosedRange)
+		XCTAssertEqual(fixtureDateClosedRange.upperBound, Defaults[closedDateKey].upperBound)
+		XCTAssertEqual(fixtureDateClosedRange.lowerBound, Defaults[closedDateKey].lowerBound)
+		Defaults[closedDateKey] = nextFixtureDateClosedRange
+		XCTAssertEqual(nextFixtureDateClosedRange.upperBound, Defaults[closedDateKey].upperBound)
+		XCTAssertEqual(nextFixtureDateClosedRange.lowerBound, Defaults[closedDateKey].lowerBound)
+	}
+
+	func testOptionalKey() {
+		// Test native support Range type
+		let key = Defaults.Key<Range<Int>?>("independentRangeOptionalKey")
+		XCTAssertNil(Defaults[key])
+		Defaults[key] = fixtureRange
+		XCTAssertEqual(fixtureRange.upperBound, Defaults[key]?.upperBound)
+		XCTAssertEqual(fixtureRange.lowerBound, Defaults[key]?.lowerBound)
+
+		// Test serializable Range type
+		let dateKey = Defaults.Key<Range<Date>?>("independentRangeDateOptionalKey")
+		XCTAssertNil(Defaults[dateKey])
+		Defaults[dateKey] = fixtureDateRange
+		XCTAssertEqual(fixtureDateRange.upperBound, Defaults[dateKey]?.upperBound)
+		XCTAssertEqual(fixtureDateRange.lowerBound, Defaults[dateKey]?.lowerBound)
+
+		// Test native support ClosedRange type
+		let closedKey = Defaults.Key<ClosedRange<Int>?>("independentClosedRangeOptionalKey")
+		XCTAssertNil(Defaults[closedKey])
+		Defaults[closedKey] = fixtureClosedRange
+		XCTAssertEqual(fixtureClosedRange.upperBound, Defaults[closedKey]?.upperBound)
+		XCTAssertEqual(fixtureClosedRange.lowerBound, Defaults[closedKey]?.lowerBound)
+
+		// Test serializable ClosedRange type
+		let closedDateKey = Defaults.Key<ClosedRange<Date>?>("independentClosedRangeDateOptionalKey")
+		XCTAssertNil(Defaults[closedDateKey])
+		Defaults[closedDateKey] = fixtureDateClosedRange
+		XCTAssertEqual(fixtureDateClosedRange.upperBound, Defaults[closedDateKey]?.upperBound)
+		XCTAssertEqual(fixtureDateClosedRange.lowerBound, Defaults[closedDateKey]?.lowerBound)
+	}
+
+	func testArrayKey() {
+		// Test native support Range type
+		let key = Defaults.Key<[Range]>("independentRangeArrayKey", default: [fixtureRange])
+		XCTAssertEqual(fixtureRange.upperBound, Defaults[key][0].upperBound)
+		XCTAssertEqual(fixtureRange.lowerBound, Defaults[key][0].lowerBound)
+		Defaults[key].append(nextFixtureRange)
+		XCTAssertEqual(fixtureRange.upperBound, Defaults[key][0].upperBound)
+		XCTAssertEqual(fixtureRange.lowerBound, Defaults[key][0].lowerBound)
+		XCTAssertEqual(nextFixtureRange.upperBound, Defaults[key][1].upperBound)
+		XCTAssertEqual(nextFixtureRange.lowerBound, Defaults[key][1].lowerBound)
+
+		// Test serializable Range type
+		let dateKey = Defaults.Key<[Range<Date>]>("independentRangeDateArrayKey", default: [fixtureDateRange])
+		XCTAssertEqual(fixtureDateRange.upperBound, Defaults[dateKey][0].upperBound)
+		XCTAssertEqual(fixtureDateRange.lowerBound, Defaults[dateKey][0].lowerBound)
+		Defaults[dateKey].append(nextFixtureDateRange)
+		XCTAssertEqual(fixtureDateRange.upperBound, Defaults[dateKey][0].upperBound)
+		XCTAssertEqual(fixtureDateRange.lowerBound, Defaults[dateKey][0].lowerBound)
+		XCTAssertEqual(nextFixtureDateRange.upperBound, Defaults[dateKey][1].upperBound)
+		XCTAssertEqual(nextFixtureDateRange.lowerBound, Defaults[dateKey][1].lowerBound)
+
+		// Test native support ClosedRange type
+		let closedKey = Defaults.Key<[ClosedRange]>("independentClosedRangeArrayKey", default: [fixtureClosedRange])
+		XCTAssertEqual(fixtureClosedRange.upperBound, Defaults[closedKey][0].upperBound)
+		XCTAssertEqual(fixtureClosedRange.lowerBound, Defaults[closedKey][0].lowerBound)
+		Defaults[closedKey].append(nextFixtureClosedRange)
+		XCTAssertEqual(fixtureClosedRange.upperBound, Defaults[closedKey][0].upperBound)
+		XCTAssertEqual(fixtureClosedRange.lowerBound, Defaults[closedKey][0].lowerBound)
+		XCTAssertEqual(nextFixtureClosedRange.upperBound, Defaults[closedKey][1].upperBound)
+		XCTAssertEqual(nextFixtureClosedRange.lowerBound, Defaults[closedKey][1].lowerBound)
+
+		// Test serializable ClosedRange type
+		let closedDateKey = Defaults.Key<[ClosedRange<Date>]>("independentClosedRangeDateArrayKey", default: [fixtureDateClosedRange])
+		XCTAssertEqual(fixtureDateClosedRange.upperBound, Defaults[closedDateKey][0].upperBound)
+		XCTAssertEqual(fixtureDateClosedRange.lowerBound, Defaults[closedDateKey][0].lowerBound)
+		Defaults[closedDateKey].append(nextFixtureDateClosedRange)
+		XCTAssertEqual(fixtureDateClosedRange.upperBound, Defaults[closedDateKey][0].upperBound)
+		XCTAssertEqual(fixtureDateClosedRange.lowerBound, Defaults[closedDateKey][0].lowerBound)
+		XCTAssertEqual(nextFixtureDateClosedRange.upperBound, Defaults[closedDateKey][1].upperBound)
+		XCTAssertEqual(nextFixtureDateClosedRange.lowerBound, Defaults[closedDateKey][1].lowerBound)
+	}
+
+	func testDictionaryKey() {
+		// Test native support Range type
+		let key = Defaults.Key<[String: Range]>("independentRangeDictionaryKey", default: ["0": fixtureRange])
+		XCTAssertEqual(fixtureRange.upperBound, Defaults[key]["0"]?.upperBound)
+		XCTAssertEqual(fixtureRange.lowerBound, Defaults[key]["0"]?.lowerBound)
+		Defaults[key]["1"] = nextFixtureRange
+		XCTAssertEqual(fixtureRange.upperBound, Defaults[key]["0"]?.upperBound)
+		XCTAssertEqual(fixtureRange.lowerBound, Defaults[key]["0"]?.lowerBound)
+		XCTAssertEqual(nextFixtureRange.upperBound, Defaults[key]["1"]?.upperBound)
+		XCTAssertEqual(nextFixtureRange.lowerBound, Defaults[key]["1"]?.lowerBound)
+
+		// Test serializable Range type
+		let dateKey = Defaults.Key<[String: Range<Date>]>("independentRangeDateDictionaryKey", default: ["0": fixtureDateRange])
+		XCTAssertEqual(fixtureDateRange.upperBound, Defaults[dateKey]["0"]?.upperBound)
+		XCTAssertEqual(fixtureDateRange.lowerBound, Defaults[dateKey]["0"]?.lowerBound)
+		Defaults[dateKey]["1"] = nextFixtureDateRange
+		XCTAssertEqual(fixtureDateRange.upperBound, Defaults[dateKey]["0"]?.upperBound)
+		XCTAssertEqual(fixtureDateRange.lowerBound, Defaults[dateKey]["0"]?.lowerBound)
+		XCTAssertEqual(nextFixtureDateRange.upperBound, Defaults[dateKey]["1"]?.upperBound)
+		XCTAssertEqual(nextFixtureDateRange.lowerBound, Defaults[dateKey]["1"]?.lowerBound)
+
+		// Test native support ClosedRange type
+		let closedKey = Defaults.Key<[String: ClosedRange]>("independentClosedRangeDictionaryKey", default: ["0": fixtureClosedRange])
+		XCTAssertEqual(fixtureClosedRange.upperBound, Defaults[closedKey]["0"]?.upperBound)
+		XCTAssertEqual(fixtureClosedRange.lowerBound, Defaults[closedKey]["0"]?.lowerBound)
+		Defaults[closedKey]["1"] = nextFixtureClosedRange
+		XCTAssertEqual(fixtureClosedRange.upperBound, Defaults[closedKey]["0"]?.upperBound)
+		XCTAssertEqual(fixtureClosedRange.lowerBound, Defaults[closedKey]["0"]?.lowerBound)
+		XCTAssertEqual(nextFixtureClosedRange.upperBound, Defaults[closedKey]["1"]?.upperBound)
+		XCTAssertEqual(nextFixtureClosedRange.lowerBound, Defaults[closedKey]["1"]?.lowerBound)
+
+		// Test serializable ClosedRange type
+		let closedDateKey = Defaults.Key<[String: ClosedRange<Date>]>("independentClosedRangeDateDictionaryKey", default: ["0": fixtureDateClosedRange])
+		XCTAssertEqual(fixtureDateClosedRange.upperBound, Defaults[closedDateKey]["0"]?.upperBound)
+		XCTAssertEqual(fixtureDateClosedRange.lowerBound, Defaults[closedDateKey]["0"]?.lowerBound)
+		Defaults[closedDateKey]["1"] = nextFixtureDateClosedRange
+		XCTAssertEqual(fixtureDateClosedRange.upperBound, Defaults[closedDateKey]["0"]?.upperBound)
+		XCTAssertEqual(fixtureDateClosedRange.lowerBound, Defaults[closedDateKey]["0"]?.lowerBound)
+		XCTAssertEqual(nextFixtureDateClosedRange.upperBound, Defaults[closedDateKey]["1"]?.upperBound)
+		XCTAssertEqual(nextFixtureDateClosedRange.lowerBound, Defaults[closedDateKey]["1"]?.lowerBound)
+	}
+}

--- a/Tests/DefaultsTests/DefaultsRangeTests.swift
+++ b/Tests/DefaultsTests/DefaultsRangeTests.swift
@@ -2,15 +2,15 @@ import Foundation
 import Defaults
 import XCTest
 
-private struct Date {
+private struct CustomDate {
 	let year: Int
 	let month: Int
 	let day: Int
 }
 
-extension Date: Defaults.Serializable {
-	public struct DateBridge: Defaults.Bridge {
-		public typealias Value = Date
+extension CustomDate: Defaults.Serializable {
+	public struct CustomDateBridge: Defaults.Bridge {
+		public typealias Value = CustomDate
 		public typealias Serializable = [Int]
 
 		public func serialize(_ value: Value?) -> Serializable? {
@@ -30,11 +30,11 @@ extension Date: Defaults.Serializable {
 		}
 	}
 
-	public static let bridge = DateBridge()
+	public static let bridge = CustomDateBridge()
 }
 
-extension Date: Comparable {
-	static func < (lhs: Date, rhs: Date) -> Bool {
+extension CustomDate: Comparable {
+	static func < (lhs: CustomDate, rhs: CustomDate) -> Bool {
 		if lhs.year != rhs.year {
 				return lhs.year < rhs.year
 		} else if lhs.month != rhs.month {
@@ -44,7 +44,7 @@ extension Date: Comparable {
 		}
 	}
 
-	static func == (lhs: Date, rhs: Date) -> Bool {
+	static func == (lhs: CustomDate, rhs: CustomDate) -> Bool {
 		lhs.year == rhs.year && lhs.month == rhs.month
 				&& lhs.day == rhs.day
 	}
@@ -53,12 +53,12 @@ extension Date: Comparable {
 // Fixtures:
 private let fixtureRange = 0..<10
 private let nextFixtureRange = 1..<20
-private let fixtureDateRange = Date(year: 2022, month: 4, day: 0)..<Date(year: 2022, month: 5, day: 0)
-private let nextFixtureDateRange = Date(year: 2022, month: 6, day: 1)..<Date(year: 2022, month: 7, day: 1)
+private let fixtureDateRange = CustomDate(year: 2022, month: 4, day: 0)..<CustomDate(year: 2022, month: 5, day: 0)
+private let nextFixtureDateRange = CustomDate(year: 2022, month: 6, day: 1)..<CustomDate(year: 2022, month: 7, day: 1)
 private let fixtureClosedRange = 0...10
 private let nextFixtureClosedRange = 1...20
-private let fixtureDateClosedRange = Date(year: 2022, month: 4, day: 0)...Date(year: 2022, month: 5, day: 0)
-private let nextFixtureDateClosedRange = Date(year: 2022, month: 6, day: 1)...Date(year: 2022, month: 7, day: 1)
+private let fixtureDateClosedRange = CustomDate(year: 2022, month: 4, day: 0)...CustomDate(year: 2022, month: 5, day: 0)
+private let nextFixtureDateClosedRange = CustomDate(year: 2022, month: 6, day: 1)...CustomDate(year: 2022, month: 7, day: 1)
 
 final class DefaultsClosedRangeTests: XCTestCase {
 	override func setUp() {
@@ -81,7 +81,7 @@ final class DefaultsClosedRangeTests: XCTestCase {
 		XCTAssertEqual(nextFixtureRange.lowerBound, Defaults[key].lowerBound)
 
 		// Test serializable Range type
-		let dateKey = Defaults.Key<Range<Date>>("independentRangeDateKey", default: fixtureDateRange)
+		let dateKey = Defaults.Key<Range<CustomDate>>("independentRangeDateKey", default: fixtureDateRange)
 		XCTAssertEqual(fixtureDateRange.upperBound, Defaults[dateKey].upperBound)
 		XCTAssertEqual(fixtureDateRange.lowerBound, Defaults[dateKey].lowerBound)
 		Defaults[dateKey] = nextFixtureDateRange
@@ -97,7 +97,7 @@ final class DefaultsClosedRangeTests: XCTestCase {
 		XCTAssertEqual(nextFixtureClosedRange.lowerBound, Defaults[closedKey].lowerBound)
 
 		// Test serializable ClosedRange type
-		let closedDateKey = Defaults.Key<ClosedRange<Date>>("independentClosedRangeDateKey", default: fixtureDateClosedRange)
+		let closedDateKey = Defaults.Key<ClosedRange<CustomDate>>("independentClosedRangeDateKey", default: fixtureDateClosedRange)
 		XCTAssertEqual(fixtureDateClosedRange.upperBound, Defaults[closedDateKey].upperBound)
 		XCTAssertEqual(fixtureDateClosedRange.lowerBound, Defaults[closedDateKey].lowerBound)
 		Defaults[closedDateKey] = nextFixtureDateClosedRange
@@ -114,7 +114,7 @@ final class DefaultsClosedRangeTests: XCTestCase {
 		XCTAssertEqual(fixtureRange.lowerBound, Defaults[key]?.lowerBound)
 
 		// Test serializable Range type
-		let dateKey = Defaults.Key<Range<Date>?>("independentRangeDateOptionalKey")
+		let dateKey = Defaults.Key<Range<CustomDate>?>("independentRangeDateOptionalKey")
 		XCTAssertNil(Defaults[dateKey])
 		Defaults[dateKey] = fixtureDateRange
 		XCTAssertEqual(fixtureDateRange.upperBound, Defaults[dateKey]?.upperBound)
@@ -128,7 +128,7 @@ final class DefaultsClosedRangeTests: XCTestCase {
 		XCTAssertEqual(fixtureClosedRange.lowerBound, Defaults[closedKey]?.lowerBound)
 
 		// Test serializable ClosedRange type
-		let closedDateKey = Defaults.Key<ClosedRange<Date>?>("independentClosedRangeDateOptionalKey")
+		let closedDateKey = Defaults.Key<ClosedRange<CustomDate>?>("independentClosedRangeDateOptionalKey")
 		XCTAssertNil(Defaults[closedDateKey])
 		Defaults[closedDateKey] = fixtureDateClosedRange
 		XCTAssertEqual(fixtureDateClosedRange.upperBound, Defaults[closedDateKey]?.upperBound)
@@ -147,7 +147,7 @@ final class DefaultsClosedRangeTests: XCTestCase {
 		XCTAssertEqual(nextFixtureRange.lowerBound, Defaults[key][1].lowerBound)
 
 		// Test serializable Range type
-		let dateKey = Defaults.Key<[Range<Date>]>("independentRangeDateArrayKey", default: [fixtureDateRange])
+		let dateKey = Defaults.Key<[Range<CustomDate>]>("independentRangeDateArrayKey", default: [fixtureDateRange])
 		XCTAssertEqual(fixtureDateRange.upperBound, Defaults[dateKey][0].upperBound)
 		XCTAssertEqual(fixtureDateRange.lowerBound, Defaults[dateKey][0].lowerBound)
 		Defaults[dateKey].append(nextFixtureDateRange)
@@ -167,7 +167,7 @@ final class DefaultsClosedRangeTests: XCTestCase {
 		XCTAssertEqual(nextFixtureClosedRange.lowerBound, Defaults[closedKey][1].lowerBound)
 
 		// Test serializable ClosedRange type
-		let closedDateKey = Defaults.Key<[ClosedRange<Date>]>("independentClosedRangeDateArrayKey", default: [fixtureDateClosedRange])
+		let closedDateKey = Defaults.Key<[ClosedRange<CustomDate>]>("independentClosedRangeDateArrayKey", default: [fixtureDateClosedRange])
 		XCTAssertEqual(fixtureDateClosedRange.upperBound, Defaults[closedDateKey][0].upperBound)
 		XCTAssertEqual(fixtureDateClosedRange.lowerBound, Defaults[closedDateKey][0].lowerBound)
 		Defaults[closedDateKey].append(nextFixtureDateClosedRange)
@@ -189,7 +189,7 @@ final class DefaultsClosedRangeTests: XCTestCase {
 		XCTAssertEqual(nextFixtureRange.lowerBound, Defaults[key]["1"]?.lowerBound)
 
 		// Test serializable Range type
-		let dateKey = Defaults.Key<[String: Range<Date>]>("independentRangeDateDictionaryKey", default: ["0": fixtureDateRange])
+		let dateKey = Defaults.Key<[String: Range<CustomDate>]>("independentRangeDateDictionaryKey", default: ["0": fixtureDateRange])
 		XCTAssertEqual(fixtureDateRange.upperBound, Defaults[dateKey]["0"]?.upperBound)
 		XCTAssertEqual(fixtureDateRange.lowerBound, Defaults[dateKey]["0"]?.lowerBound)
 		Defaults[dateKey]["1"] = nextFixtureDateRange
@@ -209,7 +209,7 @@ final class DefaultsClosedRangeTests: XCTestCase {
 		XCTAssertEqual(nextFixtureClosedRange.lowerBound, Defaults[closedKey]["1"]?.lowerBound)
 
 		// Test serializable ClosedRange type
-		let closedDateKey = Defaults.Key<[String: ClosedRange<Date>]>("independentClosedRangeDateDictionaryKey", default: ["0": fixtureDateClosedRange])
+		let closedDateKey = Defaults.Key<[String: ClosedRange<CustomDate>]>("independentClosedRangeDateDictionaryKey", default: ["0": fixtureDateClosedRange])
 		XCTAssertEqual(fixtureDateClosedRange.upperBound, Defaults[closedDateKey]["0"]?.upperBound)
 		XCTAssertEqual(fixtureDateClosedRange.lowerBound, Defaults[closedDateKey]["0"]?.lowerBound)
 		Defaults[closedDateKey]["1"] = nextFixtureDateClosedRange

--- a/readme.md
+++ b/readme.md
@@ -96,8 +96,7 @@ Add `https://github.com/sindresorhus/Defaults` in the [â€œSwift Package Managerâ
 - `Color` (SwiftUI)
 - `Codable`
 - `NSSecureCoding`
-- `Range`
-- `ClosedRange`
+- `Range`, `ClosedRange`
 
 Defaults also support the above types wrapped in `Array`, `Set`, `Dictionary`, and even wrapped in nested types. For example, `[[String: Set<[String: Int]>]]`.
 

--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ Add `https://github.com/sindresorhus/Defaults` in the [â€œSwift Package Managerâ
 - `NSSecureCoding`
 - `Range`, `ClosedRange`
 
-Defaults also support the above types wrapped in `Array`, `Set`, `Dictionary`, and even wrapped in nested types. For example, `[[String: Set<[String: Int]>]]`.
+Defaults also support the above types wrapped in `Array`, `Set`, `Dictionary`, `Range`, `ClosedRange`, and even wrapped in nested types. For example, `[[String: Set<[String: Int]>]]`.
 
 For more types, see the [enum example](#enum-example), [`Codable` example](#codable-example), or [advanced Usage](#advanced-usage). For more examples, see [Tests/DefaultsTests](./Tests/DefaultsTests).
 

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,8 @@ Add `https://github.com/sindresorhus/Defaults` in the [â€œSwift Package Managerâ
 - `Color` (SwiftUI)
 - `Codable`
 - `NSSecureCoding`
+- `Range`
+- `ClosedRange`
 
 Defaults also support the above types wrapped in `Array`, `Set`, `Dictionary`, and even wrapped in nested types. For example, `[[String: Set<[String: Int]>]]`.
 


### PR DESCRIPTION
## Summary

Fixes: #98.
Create a `RangeBridge` to support `ClosedRange` and `Range` serialization.
`RangeBridge` can serialize the object which protocol conforms to `Defaults.RangeSerializable`.
`Defaults.RangeSerializable` is a protocol that contains some essential properties for serializing and deserializing `ClosedRange` and `Range`.