### PR TITLE
Fix preserve color space for `Color` type

### DIFF
--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -442,11 +442,11 @@ extension Defaults {
 				return nil
 			}
 
-			#if os(macOS)
-			return Value(cgColor)
-			#else
-			return Value(cgColor: cgColor)
-			#endif
+			if #available(macOS 12.0, macOSApplicationExtension 12.0, *) {
+				return Value(cgColor: cgColor)
+			} else {
+				return Value(cgColor)
+			}
 		}
 	}
 }

--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -394,10 +394,7 @@ extension Defaults {
 	/**
 	The bridge which is responsible for `SwiftUI.Color` serialization and deserialization.
 
-	It is unsafe to convert `SwiftUI.Color` to `UIColor` and use `UIColor.bridge` to serialize it.
-	Because `UIColor` does not hold a color space, but `Swift.Color` does(which means color space might get lost in the conversion).
-	The bridge will always trying to preserve color space whenever `Color.cgColor` exists.
-	Only if `Color.cgColor` is `nil`, it will use `UIColor.bridge` to do serialization and deserialization.
+	It is unsafe to convert `SwiftUI.Color` to `UIColor` and use `UIColor.bridge` to serialize it, because `UIColor` does not hold a color space, but `Swift.Color` does (which means color space might get lost in the conversion). The bridge will always try to preserve the color space whenever `Color#cgColor` exists. Only when `Color#cgColor` is `nil`, will it use `UIColor.bridge` to do the serialization and deserialization.
 	*/
 	@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, iOSApplicationExtension 15.0, macOSApplicationExtension 11.0, tvOSApplicationExtension 15.0, watchOSApplicationExtension 8.0, *)
 	public struct ColorBridge: Bridge {

--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -391,6 +391,14 @@ extension Defaults {
 }
 
 extension Defaults {
+	/**
+	The bridge which is responsible for `SwiftUI.Color` serialization and deserialization.
+
+	It is unsafe to convert `SwiftUI.Color` to `UIColor` and use `UIColor.bridge` to serialize it.
+	Because `UIColor` does not hold a color space, but `Swift.Color` does(which means color space might get lost in the conversion).
+	The bridge will always trying to preserve color space whenever `Color.cgColor` exists.
+	Only if `Color.cgColor` is `nil`, it will use `UIColor.bridge` to do serialization and deserialization.
+	*/
 	@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, iOSApplicationExtension 15.0, macOSApplicationExtension 11.0, tvOSApplicationExtension 15.0, watchOSApplicationExtension 8.0, *)
 	public struct ColorBridge: Bridge {
 		public typealias Value = Color

--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -414,6 +414,7 @@ extension Defaults {
 			guard let value = value else {
 				return nil
 			}
+
 			guard
 				let cgColor = value.cgColor,
 				let colorSpace = cgColor.colorSpace?.name as? String,
@@ -443,6 +444,7 @@ extension Defaults {
 			else {
 				return nil
 			}
+
 			#if os(macOS)
 			guard let nativeColor = NativeColor(cgColor: cgColor) else {
 				return nil

--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -446,11 +446,11 @@ extension Defaults {
 			guard let nativeColor = NativeColor(cgColor: cgColor) else {
 				return nil
 			}
-			#else
-			let nativeColor = NativeColor(cgColor: cgColor)
-			#endif
 
 			return Value(nativeColor)
+			#else
+			return Value(cgColor: cgColor)
+			#endif
 		}
 	}
 }

--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -443,11 +443,7 @@ extension Defaults {
 			}
 
 			#if os(macOS)
-			guard let nativeColor = NativeColor(cgColor: cgColor) else {
-				return nil
-			}
-
-			return Value(nativeColor)
+			return Value(cgColor)
 			#else
 			return Value(cgColor: cgColor)
 			#endif


### PR DESCRIPTION
## Summary

Fixes: #97.

By default, `ColorBridge` will convert `Color` into `UIColor` in non-macOS platform.
`UIColor` does not preserve the color space, but `Color` should store the color space.

## Solution

Trying to preserve color space whenever `Color.cgColor` exists.
If `SwiftUi.Color` has `cgColor` property, Defaults will serialize and store its colorspace and components, then deserialize it with these properties.
If not, Defaults will use `NSSecureCodingBridge` to do the serialization and deserialization.

## Thanks

Thanks for your code review 😄 !