### PR TITLE
Replace standard library primary associated types with conformance

### DIFF
--- a/Sources/Defaults/Migration/v5/Migration+Extensions.swift
+++ b/Sources/Defaults/Migration/v5/Migration+Extensions.swift
@@ -198,7 +198,7 @@ extension Defaults.SetAlgebraSerializable where Self: Defaults.NativeType, Eleme
 	public typealias CodableForm = [Element.CodableForm]
 }
 
-extension Defaults.CodableType where Self: RawRepresentable<NativeForm.RawValue>, NativeForm: RawRepresentable {
+extension Defaults.CodableType where NativeForm: RawRepresentable, Self: RawRepresentable, NativeForm: RawRepresentable, RawValue == NativeForm.RawValue {
 	public func toNative() -> NativeForm {
 		NativeForm(rawValue: rawValue)!
 	}

--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -58,7 +58,7 @@ extension Defaults {
 			self.options = options
 		}
 
-		func receive(subscriber: some Subscriber<Output, Failure>) {
+		func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
 			let subscription = DefaultsSubscription(
 				subscriber: subscriber,
 				suite: suite,

--- a/Tests/DefaultsTests/DefaultsSetAlgebraTests.swift
+++ b/Tests/DefaultsTests/DefaultsSetAlgebraTests.swift
@@ -7,7 +7,7 @@ struct DefaultsSetAlgebra<Element: Defaults.Serializable & Hashable>: SetAlgebra
 
 	init() {}
 
-	init(_ sequence: __owned some Sequence<Element>) {
+	init<S: Sequence>(_ sequence: __owned S) where Element == S.Element {
 		self.store = Set(sequence)
 	}
 


### PR DESCRIPTION
## Summary

Xcode 14 has the macOS 12.3 SDK, where this standard library does not support primary associated types.

Reference: https://forums.swift.org/t/xcode-14-rc-cannot-specialize-protocol-type/60171/22

## Thanks

Thanks for your code review 😄 !