### PR TITLE
Support dynamic default value

### DIFF
--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -42,12 +42,13 @@ public enum Defaults {
 
 	public final class Key<Value: Serializable>: AnyKey {
 		/**
-		The `defaultValueGetter` will be executed in these situations:
+		It will be executed in these situations:
 
 		- `UserDefaults.object(forKey: string)` return `nil`
 		- `bridge` cannot deserialize `Value` from `UserDefaults`
-		 */
+		*/
 		private let defaultValueGetter: () -> Value
+
 		public var defaultValue: Value { defaultValueGetter() }
 
 		/**
@@ -73,9 +74,17 @@ public enum Defaults {
 		}
 
 		/**
-		Create a defaults key with dynamic getter.
+		Create a defaults key with a dynamic default value.
+		
+		This can be useful in cases where you cannot define a static default value as it may change during the lifetime of the app.
 
-		- NOTE: If using `defaultValueGetter`, it will not set the default value in the actual UserDefaults.
+		```swift
+		extension Defaults.Keys {
+			static let camera = Key<AVCaptureDevice?>("camera") { .default(for: .video) }
+		}
+		```
+
+		- Note: This initializer will not set the default value in the actual `UserDefaults`. This should not matter much though. It's only really useful if you use legacy KVO bindings.
 		*/
 		public init(_ key: String, suite: UserDefaults = .standard, default defaultValueGetter: @escaping () -> Value) {
 			self.defaultValueGetter = defaultValueGetter

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -44,8 +44,8 @@ public enum Defaults {
 		/**
 		It will be executed in these situations:
 
-		- `UserDefaults.object(forKey: string)` return `nil`
-		- `bridge` cannot deserialize `Value` from `UserDefaults`
+		- `UserDefaults.object(forKey: string)` returns `nil`
+		- A `bridge` cannot deserialize `Value` from `UserDefaults`
 		*/
 		private let defaultValueGetter: () -> Value
 

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -41,24 +41,22 @@ public enum Defaults {
 	}
 
 	public final class Key<Value: Serializable>: AnyKey {
-		public typealias DefaultGetter = () -> Value
 		/**
 		The `defaultGetter` will be executed in these situations:
 
 		- `UserDefaults.object(forKey: string)` return `nil`
 		- `bridge` cannot deserialize `Value` from `UserDefaults`
 		 */
-		private let defaultGetter: DefaultGetter
-		public var defaultValue: Value { defaultGetter() }
+		private let defaultValueGetter: () -> Value
+		public var defaultValue: Value { defaultValueGetter() }
 
 		/**
 		Create a defaults key.
 
 		The `default` parameter can be left out if the `Value` type is an optional.
 		*/
-		public init(_ key: String, default defaultGetter: @autoclosure @escaping DefaultGetter, suite: UserDefaults = .standard) {
-			let defaultValue = defaultGetter()
-			self.defaultGetter = defaultGetter
+		public init(_ key: String, default defaultValue: Value, suite: UserDefaults = .standard) {
+			self.defaultValueGetter = { defaultValue }
 
 			super.init(name: key, suite: suite)
 
@@ -79,8 +77,8 @@ public enum Defaults {
 
 		- NOTE: If using `defaultGetter`, it will not set the default value in the actual UserDefaults.
 		*/
-		public init(_ key: String, default defaultGetter: @escaping DefaultGetter, suite: UserDefaults = .standard) {
-			self.defaultGetter = defaultGetter
+		public init(_ key: String, suite: UserDefaults = .standard, default defaultValueGetter: @escaping () -> Value) {
+			self.defaultValueGetter = defaultValueGetter
 
 			super.init(name: key, suite: suite)
 		}

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -42,7 +42,7 @@ public enum Defaults {
 
 	public final class Key<Value: Serializable>: AnyKey {
 		/**
-		The `defaultGetter` will be executed in these situations:
+		The `defaultValueGetter` will be executed in these situations:
 
 		- `UserDefaults.object(forKey: string)` return `nil`
 		- `bridge` cannot deserialize `Value` from `UserDefaults`
@@ -75,7 +75,7 @@ public enum Defaults {
 		/**
 		Create a defaults key with dynamic getter.
 
-		- NOTE: If using `defaultGetter`, it will not set the default value in the actual UserDefaults.
+		- NOTE: If using `defaultValueGetter`, it will not set the default value in the actual UserDefaults.
 		*/
 		public init(_ key: String, suite: UserDefaults = .standard, default defaultValueGetter: @escaping () -> Value) {
 			self.defaultValueGetter = defaultValueGetter

--- a/readme.md
+++ b/readme.md
@@ -123,8 +123,7 @@ if let name = Defaults[.name] {
 
 The default value is then `nil`.
 
-Sometimes you cannot define a static default value as it may change during the lifetime of the app.
-`Defaults.Key` also support dynamic default value.
+You can also specify a dynamic default value. This can be useful when the default value may change during the lifetime of the app:
 
 ```swift
 extension Defaults.Keys {
@@ -393,7 +392,7 @@ print(UserDefaults.standard.bool(forKey: Defaults.Keys.isUnicornMode.name))
 ```
 
 > **Note** 
-> `Defaults.Key` with dynamic default value will not register the `default` value in `UserDefaults`.
+> A `Defaults.Key` with a dynamic default value will not register the default value in `UserDefaults`.
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,15 @@ if let name = Defaults[.name] {
 
 The default value is then `nil`.
 
+Sometimes you cannot define a static default value as it may change during the lifetime of the app.
+`Defaults.Key` also support dynamic default value.
+
+```swift
+extension Defaults.Keys {
+	static let camera = Key<AVCaptureDevice?>("camera") { .default(for: .video) }
+}
+```
+
 ---
 
 ### Enum example
@@ -382,6 +391,9 @@ extension Defaults.Keys {
 print(UserDefaults.standard.bool(forKey: Defaults.Keys.isUnicornMode.name))
 //=> true
 ```
+
+> **Note** 
+> `Defaults.Key` with dynamic default value will not register the `default` value in `UserDefaults`.
 
 ## API
 


### PR DESCRIPTION
## Summary

Fixes: #108 .

`Defaults` now accept default value as a `getter`.

## Approach

Replace default value's type with type `typealias DefaultGetter = () -> Value`.
And change `Key.defaultValue` to a computed property which getter is `DefaultGetter`.

## Thanks

Sorry for the delay of this PR and thanks for your code review 😄 !