### PR TITLE
Make it possible to import the package once for a whole project

### DIFF
--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -35,6 +35,9 @@ public enum Defaults {
 	}
 }
 
+public typealias _Defaults = Defaults
+public typealias _Default = Default
+
 extension Defaults {
 	// We cannot use `Key` as the container for keys because of "Static stored properties not supported in generic types".
 	/**

--- a/Sources/Defaults/Documentation.docc/Documentation.md
+++ b/Sources/Defaults/Documentation.docc/Documentation.md
@@ -30,6 +30,17 @@ Defaults[.quality] = 0.5
 
 [Learn More](https://github.com/sindresorhus/Defaults#usage)
 
+### Tip
+
+If you don't want to import this package in every file you use it, add the below to a file in your app. You can then use `Defaults` and `@Default` from anywhere without an import.
+
+```swift
+import Defaults
+
+typealias Defaults = _Defaults
+typealias Default = _Default
+```
+
 ## Topics
 
 ### Essentials


### PR DESCRIPTION
We have to export the underscored names as Swift does not have any way to disambiguate names.