### PR TITLE
Add @PublishedDefault for ObservableObject

### DIFF
--- a/Sources/Defaults/PublishedDefault.swift
+++ b/Sources/Defaults/PublishedDefault.swift
@@ -1,47 +1,57 @@
 import Combine
 
+/**
+PublishedDefault will trigger `objectWillChange` in the `ObservableObject` when the value is changed.
+
+- Important: By default, `PublishedDefault` does not observe changes made to the corresponding value outside of the `PublishedDefault`.
+Only changes made via this `@PublishedDefault` will trigger `objectWillChange`.
+
+To ensure that changes made to Defaults elsewhere also trigger `objectWillChange`, you need to call `observeDefaults` once in the `ObservableObject`.
+
+```swift
+extension Defaults.Keys {
+    static let opacity = Key<Double>("opacity", default: 1)
+}
+
+class ViewModel: ObservableObject {
+    @PublishedDefault(.opacity) var opacity
+
+    init() {
+        observeDefaults()
+    }
+}
+```
+*/
 @propertyWrapper
-public struct PublishedDefault<Value: _DefaultsSerializable> {
+public class PublishedDefault<Value: _DefaultsSerializable> {
     private let key: Defaults.Key<Value>
-    private var publisher: AnyPublisher<Value, Never>?
-    
+    private var defaultPublisher: AnyPublisher<Value, Never>?
+    private var objectSubscription: AnyCancellable?
+
     private var value: Value {
         get { Defaults[key] }
         set { Defaults[key] = newValue }
     }
-    
-    /**
-    Get/set a `Defaults` item and also trigger `objectWillChange` in the `ObservableObject` when the value changes.
-     
-    - Important: Like `@Published`, `@PublishedDefault` does not observe the change of the corresponding value. Only changes made via this `@PublishedDefault` will trigger `ObservableObject`'s `objectWillChange`.
-     
-    ```swift
-    extension Defaults.Keys {
-        static let opacity = Key<Double>("opacity", default: 1)
-    }
-     
-    class ViewModel: ObservableObject {
-        @PublishedDefault(.opacity) var opacity
-    }
-    ```
-    */
+
     public init(_ key: Defaults.Key<Value>) {
         self.key = key
     }
-    
+
     /**
     The getter/setter in a `ObservableObject`.
     */
     public static subscript<Object: AnyObject>(
         _enclosingInstance instance: Object,
         wrapped _: ReferenceWritableKeyPath<Object, Value>,
-        storage storageKeyPath: ReferenceWritableKeyPath<Object, Self>
+        storage storageKeyPath: ReferenceWritableKeyPath<Object, PublishedDefault>
     ) -> Value {
         get {
             instance[keyPath: storageKeyPath].value
         }
         set {
-            if let observable = instance as? any ObservableObject,
+            // Skip if subscrition is already acting
+            if instance[keyPath: storageKeyPath].objectSubscription == nil,
+               let observable = instance as? any ObservableObject,
                let objectWillChange = observable.objectWillChange as any Publisher as? ObservableObjectPublisher
             {
                 objectWillChange.send()
@@ -49,35 +59,33 @@ public struct PublishedDefault<Value: _DefaultsSerializable> {
             instance[keyPath: storageKeyPath].value = newValue
         }
     }
-    
-    @available(*, unavailable, message: "@Published is only available on properties of AnyObject")
+
+    @available(*, unavailable, message: "@PublishedDefault is only available on properties of AnyObject")
     public var wrappedValue: Value {
         get { value }
         set { value = newValue }
     }
-    
+
     public var projectedValue: some Publisher<Value, Never> {
-        mutating get {
-            if publisher == nil {
-                publisher = Defaults.publisher(key, options: [.initial])
-                    .map(\.newValue)
-                    .eraseToAnyPublisher()
-            }
-            return publisher!
+        if defaultPublisher == nil {
+            defaultPublisher = Defaults.publisher(key, options: [.initial])
+                .map(\.newValue)
+                .eraseToAnyPublisher()
         }
+        return defaultPublisher!
     }
 
     /**
     Reset the key back to its default value.
-     
+
     ```swift
     extension Defaults.Keys {
         static let opacity = Key<Double>("opacity", default: 1)
     }
-     
+
     class ViewModel: ObservableObject {
         @PublishedDefault(.opacity) var opacity
-     
+
         func reset() {
             _opacity.reset()
         }
@@ -86,5 +94,31 @@ public struct PublishedDefault<Value: _DefaultsSerializable> {
     */
     public func reset() {
         key.reset()
+    }
+}
+
+// A type-erase protocol used to subscribe Defaults on ObservableObject.
+protocol _PublishedDefaultProtocol {
+    func subscribe(to publisher: ObservableObjectPublisher)
+}
+
+extension PublishedDefault: _PublishedDefaultProtocol {
+    func subscribe(to publisher: ObservableObjectPublisher) {
+        objectSubscription = projectedValue
+            .dropFirst()
+            .sink { _ in
+                publisher.send()
+            }
+    }
+}
+
+public extension ObservableObject where ObjectWillChangePublisher == ObservableObjectPublisher {
+    /**
+    Begin observing the Default value so that changes made to Defaults outside of the ObservableObject will also trigger objectWillChange.
+    */
+    func observeDefaults() {
+        for (_, property) in Mirror(reflecting: self).children {
+            (property as? _PublishedDefaultProtocol)?.subscribe(to: objectWillChange)
+        }
     }
 }

--- a/Sources/Defaults/PublishedDefault.swift
+++ b/Sources/Defaults/PublishedDefault.swift
@@ -1,0 +1,90 @@
+import Combine
+
+@propertyWrapper
+public struct PublishedDefault<Value: _DefaultsSerializable> {
+    private let key: Defaults.Key<Value>
+    private var publisher: AnyPublisher<Value, Never>?
+    
+    private var value: Value {
+        get { Defaults[key] }
+        set { Defaults[key] = newValue }
+    }
+    
+    /**
+    Get/set a `Defaults` item and also trigger `objectWillChange` in the `ObservableObject` when the value changes.
+     
+    - Important: Like `@Published`, `@PublishedDefault` does not observe the change of the corresponding value. Only changes made via this `@PublishedDefault` will trigger `ObservableObject`'s `objectWillChange`.
+     
+    ```swift
+    extension Defaults.Keys {
+        static let opacity = Key<Double>("opacity", default: 1)
+    }
+     
+    class ViewModel: ObservableObject {
+        @PublishedDefault(.opacity) var opacity
+    }
+    ```
+    */
+    public init(_ key: Defaults.Key<Value>) {
+        self.key = key
+    }
+    
+    /**
+    The getter/setter in a `ObservableObject`.
+    */
+    public static subscript<Object: AnyObject>(
+        _enclosingInstance instance: Object,
+        wrapped _: ReferenceWritableKeyPath<Object, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<Object, Self>
+    ) -> Value {
+        get {
+            instance[keyPath: storageKeyPath].value
+        }
+        set {
+            if let observable = instance as? any ObservableObject,
+               let objectWillChange = observable.objectWillChange as any Publisher as? ObservableObjectPublisher
+            {
+                objectWillChange.send()
+            }
+            instance[keyPath: storageKeyPath].value = newValue
+        }
+    }
+    
+    @available(*, unavailable, message: "@Published is only available on properties of AnyObject")
+    public var wrappedValue: Value {
+        get { value }
+        set { value = newValue }
+    }
+    
+    public var projectedValue: some Publisher<Value, Never> {
+        mutating get {
+            if publisher == nil {
+                publisher = Defaults.publisher(key, options: [.initial])
+                    .map(\.newValue)
+                    .eraseToAnyPublisher()
+            }
+            return publisher!
+        }
+    }
+
+    /**
+    Reset the key back to its default value.
+     
+    ```swift
+    extension Defaults.Keys {
+        static let opacity = Key<Double>("opacity", default: 1)
+    }
+     
+    class ViewModel: ObservableObject {
+        @PublishedDefault(.opacity) var opacity
+     
+        func reset() {
+            _opacity.reset()
+        }
+    }
+    ```
+    */
+    public func reset() {
+        key.reset()
+    }
+}

--- a/Tests/DefaultsTests/DefaultsPublishedDefaultTests.swift
+++ b/Tests/DefaultsTests/DefaultsPublishedDefaultTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+import Combine
+import Defaults
+
+@available(macOS 11.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+private extension Defaults.Keys {
+    static let opacity = Key<Double>("opacity", default: 0.5)
+}
+
+@available(macOS 11.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+final class ViewModel: ObservableObject {
+    @PublishedDefault(.opacity) var opacity
+}
+
+@available(macOS 11.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+final class DefaultsPublishedDefaultTests: XCTestCase {
+    
+    var cancellables: [AnyCancellable] = []
+    
+    override func setUp() {
+        Defaults.removeAll()
+    }
+
+    override func tearDown() {
+        cancellables = []
+    }
+
+    func testObjectWillChange() {
+        let viewModel = ViewModel()
+        let objectExpectation = expectation(description: "Expected ObservableObject's fire")
+
+        viewModel.objectWillChange
+            .sink {
+                objectExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        viewModel.opacity = 1
+        waitForExpectations(timeout: 1)
+        
+        XCTAssertEqual(viewModel.opacity, 1)
+        XCTAssertEqual(Defaults[.opacity], 1)
+    }
+    
+    func testProjectValue() {
+        let viewModel = ViewModel()
+        let valueExpectation = expectation(description: "Expected Opacity Value")
+        var receivedValue: Double?
+        
+        viewModel.$opacity
+            // skip the initial value
+            .dropFirst()
+            .sink { newValue in
+                receivedValue = newValue
+                valueExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        // Changing value via Defaults directly also fire the projecttedValue
+        Defaults[.opacity] = 1
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(receivedValue, 1)
+    }
+    
+    func testObservation() {
+        let viewModel = ViewModel()
+        // To enable Defaults observation, call observeDefaults.
+        viewModel.observeDefaults()
+        let objectExpectation = expectation(description: "Expected ObservableObject's fire")
+        
+        viewModel.objectWillChange
+            .sink {
+                objectExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        // Change value via Defaults instead of ObservableObject itself
+        Defaults[.opacity] = 1
+        waitForExpectations(timeout: 1)
+        
+        XCTAssertEqual(viewModel.opacity, 1)
+    }
+}


### PR DESCRIPTION
## Introduction
Hi. Thanks for the awesome Defaults framework!

This PR add a new property wrapper `@PublishedDefault`, that is used exclusively for `ObservableObject`.

`@PublishedDefault` will trigger `objectWillChange` when changing the value of Defaults via `ObservableObject`.

You can use it like this

```swift
extension Defaults.Keys {
    static let opacity = Key<Double>("opacity", default: 0.5)
}

final class ViewModel: ObservableObject {
    @PublishedDefault(.opacity) var opacity
}

viewModel.opacity = 1.0
viewModel.objectWillChange // => fire Void
viewModel.$opacity // => fire 1.0
```

## Detail
I used a feature called [Referencing the enclosing 'self' in a wrapper type](https://github.com/apple/swift-evolution/blob/main/proposals/0258-property-wrappers.md#referencing-the-enclosing-self-in-a-wrapper-type) that is not in the Swift documentation but is in the Property Wrapper's Proposal. This feature makes the property wrapper can access the object that holding itself. This is how `@Published` work.

However, you can access the enclosing object only when that object reads/write the corresponding value, instead of all the time.

Due to this limitation, `@PublishedDefault` CANNOT observe changes in the value of the underlying `UserDefaults`, and can only trigger `objectWillChange` if the value change is made by the `ObservableObject` that holds it.

```swift
Defaults[.opacity] = 0.2

// neither of the following will fire
viewModel.objectWillChange
viewModel.$opacity
```

(Well, technically you can let `@PublsihedDefaults` hold a reference to the object when read/write occurs to make the observation work. But that doesn't smell good, so I didn't try it.)

It would be nice if you can also check the comments.

This PR also fix #48 

## Other helpful reference:
https://www.swiftbysundell.com/articles/accessing-a-swift-property-wrappers-enclosing-instance/
https://www.avanderlee.com/swift/appstorage-explained/#creating-an-alternative-solution-for-reading-and-writing-user-defaults-through-a-property-wrapper

## TODO
- [ ] Use `AnyObject` as generic constraint
  - try to cast it to `ObservableObject` if possible, instead of constrain it as `ObservableObject` only.
- [ ] Fatal Error's message
- [ ] Update `@Defaults` comment and README
- [ ] Use correct indentation