### PR TITLE
Switch from deprecated NSSecureCoding API

### DIFF
--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -50,7 +50,7 @@ extension Defaults {
 This exists to avoid compiler ambiguity.
 */
 extension Defaults {
-	public struct CodableNSSecureCodingBridge<Value: Codable & NSSecureCoding>: CodableBridge {}
+	public struct CodableNSSecureCodingBridge<Value: Codable & NSSecureCoding & NSObject>: CodableBridge {}
 }
 
 extension Defaults {
@@ -79,7 +79,7 @@ extension Defaults {
 }
 
 extension Defaults {
-	public struct NSSecureCodingBridge<Value: NSSecureCoding>: Bridge {
+	public struct NSSecureCodingBridge<Value: NSSecureCoding & NSObject>: Bridge {
 		public typealias Value = Value
 		public typealias Serializable = Data
 
@@ -97,7 +97,7 @@ extension Defaults {
 			}
 
 			do {
-				return try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(object) as? Value
+				return try NSKeyedUnarchiver.unarchivedObject(ofClass: Value.self, from: object)
 			} catch {
 				print(error)
 				return nil

--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -85,11 +85,11 @@ extension Defaults.Serializable where Self: Codable {
 	public static var bridge: Defaults.TopLevelCodableBridge<Self> { Defaults.TopLevelCodableBridge() }
 }
 
-extension Defaults.Serializable where Self: Codable & NSSecureCoding {
+extension Defaults.Serializable where Self: Codable & NSSecureCoding & NSObject {
 	public static var bridge: Defaults.CodableNSSecureCodingBridge<Self> { Defaults.CodableNSSecureCodingBridge() }
 }
 
-extension Defaults.Serializable where Self: Codable & NSSecureCoding & Defaults.PreferNSSecureCoding {
+extension Defaults.Serializable where Self: Codable & NSSecureCoding & NSObject & Defaults.PreferNSSecureCoding {
 	public static var bridge: Defaults.NSSecureCodingBridge<Self> { Defaults.NSSecureCodingBridge() }
 }
 
@@ -104,7 +104,7 @@ extension Defaults.Serializable where Self: Codable & RawRepresentable & Default
 extension Defaults.Serializable where Self: RawRepresentable {
 	public static var bridge: Defaults.RawRepresentableBridge<Self> { Defaults.RawRepresentableBridge() }
 }
-extension Defaults.Serializable where Self: NSSecureCoding {
+extension Defaults.Serializable where Self: NSSecureCoding & NSObject {
 	public static var bridge: Defaults.NSSecureCodingBridge<Self> { Defaults.NSSecureCodingBridge() }
 }
 

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -41,7 +41,7 @@ public protocol _DefaultsSetAlgebraSerializable: SetAlgebra, Defaults.Serializab
 public protocol _DefaultsCodableBridge: Defaults.Bridge where Serializable == String, Value: Codable {}
 
 public protocol _DefaultsPreferRawRepresentable: RawRepresentable {}
-public protocol _DefaultsPreferNSSecureCoding: NSSecureCoding {}
+public protocol _DefaultsPreferNSSecureCoding: NSObject, NSSecureCoding {}
 
 // Essential properties for serializing and deserializing `ClosedRange` and `Range`.
 public protocol _DefaultsRange {


### PR DESCRIPTION
Fixes #131

The new API requires NSObject inheritance, so I had to add some more constraints.