### PR TITLE
Support `NSUbiquitousKeyValueStore`

### DIFF
--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -418,7 +418,7 @@ extension Defaults {
 				return nil
 			}
 
-			if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, iOSApplicationExtension 15.0, macOSApplicationExtension 12.0, tvOSApplicationExtension 15.0, watchOSApplicationExtension 8.0, *) {
+			if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, iOSApplicationExtension 15.0, macOSApplicationExtension 12.0, tvOSApplicationExtension 15.0, watchOSApplicationExtension 8.0, visionOSApplicationExtension 1.0, *) {
 				return Value(cgColor: cgColor)
 			}
 

--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -164,3 +164,6 @@ extension NSColor: Defaults.Serializable {}
 */
 extension UIColor: Defaults.Serializable {}
 #endif
+
+extension NSUbiquitousKeyValueStore: Defaults.KeyValueStore {}
+extension UserDefaults: Defaults.KeyValueStore {}

--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -167,3 +167,14 @@ extension UIColor: Defaults.Serializable {}
 
 extension NSUbiquitousKeyValueStore: Defaults.KeyValueStore {}
 extension UserDefaults: Defaults.KeyValueStore {}
+
+extension _DefaultsLockProtocol {
+	@discardableResult
+	func with<R>(_ body: @Sendable () throws -> R) rethrows -> R where R : Sendable {
+		self.lock()
+		defer {
+			self.unlock()
+		}
+		return try body()
+	}
+}

--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -170,7 +170,7 @@ extension UserDefaults: Defaults.KeyValueStore {}
 
 extension _DefaultsLockProtocol {
 	@discardableResult
-	func with<R>(_ body: @Sendable () throws -> R) rethrows -> R where R : Sendable {
+	func with<R>(_ body: @Sendable () throws -> R) rethrows -> R where R: Sendable {
 		self.lock()
 		defer {
 			self.unlock()

--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -165,10 +165,10 @@ extension NSColor: Defaults.Serializable {}
 extension UIColor: Defaults.Serializable {}
 #endif
 
-extension NSUbiquitousKeyValueStore: Defaults.KeyValueStore {}
-extension UserDefaults: Defaults.KeyValueStore {}
+extension NSUbiquitousKeyValueStore: DefaultsKeyValueStore {}
+extension UserDefaults: DefaultsKeyValueStore {}
 
-extension _DefaultsLockProtocol {
+extension DefaultsLockProtocol {
 	@discardableResult
 	func with<R>(_ body: @Sendable () throws -> R) rethrows -> R where R: Sendable {
 		self.lock()

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -74,5 +74,5 @@ protocol _DefaultsLockProtocol {
 
 	func unlock()
 
-	func with<R>(_ body: @Sendable () throws -> R) rethrows -> R where R : Sendable
+	func with<R>(_ body: @Sendable () throws -> R) rethrows -> R where R: Sendable
 }

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -58,8 +58,19 @@ Essential properties for synchronizing a key value store.
 */
 public protocol _DefaultsKeyValueStore {
 	func object(forKey aKey: String) -> Any?
+
 	func set(_ anObject: Any?, forKey aKey: String)
+
 	func removeObject(forKey aKey: String)
+
 	@discardableResult
 	func synchronize() -> Bool
+}
+
+protocol _DefaultsLockProtocol {
+	static func make() -> Self
+
+	func lock()
+
+	func unlock()
 }

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -73,4 +73,6 @@ protocol _DefaultsLockProtocol {
 	func lock()
 
 	func unlock()
+
+	func with<R>(_ body: @Sendable () throws -> R) rethrows -> R where R : Sendable
 }

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -52,3 +52,14 @@ public protocol _DefaultsRange {
 
 	init(uncheckedBounds: (lower: Bound, upper: Bound))
 }
+
+/**
+Essential properties for synchronizing a key value store.
+*/
+public protocol _DefaultsKeyValueStore {
+	func object(forKey aKey: String) -> Any?
+	func set(_ anObject: Any?, forKey aKey: String)
+	func removeObject(forKey aKey: String)
+	@discardableResult
+	func synchronize() -> Bool
+}

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -56,7 +56,7 @@ public protocol _DefaultsRange {
 /**
 Essential properties for synchronizing a key value store.
 */
-public protocol _DefaultsKeyValueStore {
+protocol DefaultsKeyValueStore {
 	func object(forKey aKey: String) -> Any?
 
 	func set(_ anObject: Any?, forKey aKey: String)
@@ -67,7 +67,7 @@ public protocol _DefaultsKeyValueStore {
 	func synchronize() -> Bool
 }
 
-protocol _DefaultsLockProtocol {
+protocol DefaultsLockProtocol {
 	static func make() -> Self
 
 	func lock()

--- a/Sources/Defaults/Defaults+iCloud.swift
+++ b/Sources/Defaults/Defaults+iCloud.swift
@@ -22,7 +22,7 @@ public enum DataSource {
 private enum SyncStatus {
 	case idle
 	case syncing
-    case completed
+	case completed
 }
 
 extension Defaults {
@@ -154,7 +154,7 @@ extension Defaults {
 		- Parameter source: Sync key from which data source(remote or local).
 		*/
 		private func syncKey(_ key: Defaults.Keys, _ source: DataSource) async {
-            Self.logKeySyncStatus(key, source: source, syncStatus: .idle)
+			Self.logKeySyncStatus(key, source: source, syncStatus: .idle)
 			switch source {
 			case .remote:
 				await syncFromRemote(key: key)
@@ -330,9 +330,9 @@ extension Defaults.iCloudSynchronizer {
 		var status: String
 		var valueDescription = " "
 		switch syncStatus {
-        case .idle:
-            status = "Try synchronizing"
-        case .syncing:
+		case .idle:
+			status = "Try synchronizing"
+		case .syncing:
 			status = "Synchronizing"
 			valueDescription = " with value \(value ?? "nil") "
 		case .completed:
@@ -411,28 +411,28 @@ extension Defaults {
 		Add the keys to be automatically synced.
 		*/
 		public static func add(_ keys: Defaults.Keys...) {
-            synchronizer.add(keys)
+			synchronizer.add(keys)
 		}
 
 		/**
 		 Remove the keys that are set to be automatically synced.
 		*/
 		public static func remove(_ keys: Defaults.Keys...) {
-            synchronizer.remove(keys)
+			synchronizer.remove(keys)
 		}
 
 		/**
 		Remove all keys that are set to be automatically synced.
 		*/
 		public static func removeAll() {
-            synchronizer.removeAll()
+			synchronizer.removeAll()
 		}
 
 		/**
 		Explicitly synchronizes in-memory keys and values with those stored on disk.
 		*/
 		public static func synchronize() {
-            synchronizer.synchronize()
+			synchronizer.synchronize()
 		}
 
 		/**
@@ -446,7 +446,7 @@ extension Defaults {
 		Create synchronization tasks for all the keys that have been added to the `Defaults.iCloud`.
 		*/
 		public static func syncWithoutWaiting() {
-            synchronizer.syncWithoutWaiting()
+			synchronizer.syncWithoutWaiting()
 		}
 
 		/**
@@ -458,7 +458,7 @@ extension Defaults {
 		- Note: `source` should be specify if `key` has not been added to `Defaults.iCloud`.
 		*/
 		public static func syncWithoutWaiting(_ keys: Defaults.Keys..., source: DataSource? = nil) {
-            synchronizer.syncWithoutWaiting(keys, source)
+			synchronizer.syncWithoutWaiting(keys, source)
 		}
 	}
 }

--- a/Sources/Defaults/Defaults+iCloud.swift
+++ b/Sources/Defaults/Defaults+iCloud.swift
@@ -1,0 +1,432 @@
+#if !os(macOS)
+import UIKit
+#endif
+import Combine
+import Foundation
+
+/// Represent  different data sources available for synchronization.
+public enum DataSource {
+	/// Using `key.suite` as data source.
+	case local
+	/// Using `NSUbiquitousKeyValueStore` as data source.
+	case remote
+}
+
+private enum SyncStatus {
+	case start
+	case isSyncing
+	case finish
+}
+
+extension Defaults {
+	/**
+	Automatically synchronizing ``keys`` when they are changed.
+	*/
+	public final class iCloud: NSObject {
+		override init() {
+			self.remoteStorage = NSUbiquitousKeyValueStore.default
+			super.init()
+			registerNotifications()
+			remoteStorage.synchronize()
+		}
+
+		init(remoteStorage: KeyValueStore) {
+			self.remoteStorage = remoteStorage
+			super.init()
+			registerNotifications()
+			remoteStorage.synchronize()
+		}
+
+		deinit {
+			removeAll()
+		}
+
+		/**
+		Set of keys which need to sync.
+		*/
+		private var keys: Set<Defaults.Keys> = []
+
+		/**
+		Key for recording the synchronization between `NSUbiquitousKeyValueStore` and `UserDefaults`.
+		*/
+		private let defaultsSyncKey = "__DEFAULTS__synchronizeTimestamp"
+
+		/**
+		A remote key value storage.
+		*/
+		private var remoteStorage: KeyValueStore
+
+		/**
+		A local storage responsible for recording synchronization timestamp.
+		*/
+		private let localStorage: KeyValueStore = UserDefaults.standard
+
+		/**
+		A FIFO queue used to serialize synchronization on keys.
+		*/
+		private let backgroundQueue = TaskQueue(priority: .background)
+
+		/**
+		A thread-safe synchronization status monitor for `keys`.
+		*/
+		private var atomicSet: AtomicSet<Defaults.Keys> = .init()
+
+		/**
+		Add new key and start to observe its changes.
+		*/
+		private func add(_ keys: [Defaults.Keys]) {
+			self.keys.formUnion(keys)
+			for key in keys {
+				addObserver(key)
+			}
+		}
+
+		/**
+		Remove key and stop the observation.
+		*/
+		private func remove(_ keys: [Defaults.Keys]) {
+			self.keys.subtract(keys)
+			for key in keys {
+				removeObserver(key)
+			}
+		}
+
+		/**
+		Remove all sync keys.
+		*/
+		private func removeAll() {
+			for key in keys {
+				removeObserver(key)
+			}
+			keys.removeAll()
+			atomicSet.removeAll()
+		}
+
+		/**
+		Explicitly synchronizes in-memory keys and values with those stored on disk.
+		*/
+		private func synchronize() {
+			remoteStorage.synchronize()
+		}
+
+		/**
+		Synchronize the specified `keys` from the given `source`.
+
+		- Parameter keys: If the keys parameter is an empty array, the method will use the keys that were added to `Defaults.iCloud`.
+		- Parameter source: Sync keys from which data source(remote or local).
+		*/
+		private func syncKeys(_ keys: [Defaults.Keys] = [], _ source: DataSource? = nil) {
+			let keys = keys.isEmpty ? Array(self.keys) : keys
+			let latest = source ?? latestDataSource()
+
+			backgroundQueue.sync {
+				for key in keys {
+					await self.syncKey(key, latest)
+				}
+			}
+		}
+
+		/**
+		Synchronize the specified `key` from the  given `source`.
+
+		- Parameter key: The key to synchronize.
+		- Parameter source: Sync key from which data source(remote or local).
+		*/
+		private func syncKey(_ key: Defaults.Keys, _ source: DataSource) async {
+			Self.logKeySyncStatus(key, source, .start)
+			atomicSet.insert(key)
+			await withCheckedContinuation { continuation in
+				let completion = {
+					continuation.resume()
+				}
+				switch source {
+				case .remote:
+					syncFromRemote(key: key, completion)
+					recordTimestamp(.local)
+				case .local:
+					syncFromLocal(key: key, completion)
+					recordTimestamp(.remote)
+				}
+			}
+			Self.logKeySyncStatus(key, source, .finish)
+			atomicSet.remove(key)
+		}
+
+		/**
+		Only update the value if it can be retrieved from the remote storage.
+		*/
+		private func syncFromRemote(key: Defaults.Keys, _ completion: @escaping () -> Void) {
+			guard let value = remoteStorage.object(forKey: key.name) else {
+				completion()
+				return
+			}
+
+			Task { @MainActor in
+				Defaults.iCloud.logKeySyncStatus(key, .remote, .isSyncing, value)
+				key.suite.set(value, forKey: key.name)
+				completion()
+			}
+		}
+
+		/**
+		Retrieve a value from local storage, and if it does not exist, remove it from the remote storage.
+		*/
+		private func syncFromLocal(key: Defaults.Keys, _ completion: @escaping () -> Void) {
+			guard let value = key.suite.object(forKey: key.name) else {
+				Defaults.iCloud.logKeySyncStatus(key, .local, .isSyncing, nil)
+				remoteStorage.removeObject(forKey: key.name)
+				syncRemoteStorageOnChange()
+				completion()
+				return
+			}
+
+			Defaults.iCloud.logKeySyncStatus(key, .local, .isSyncing, value)
+			remoteStorage.set(value, forKey: key.name)
+			syncRemoteStorageOnChange()
+			completion()
+		}
+
+		/**
+		Explicitly synchronizes in-memory keys and values when a value is changed.
+		*/
+		private func syncRemoteStorageOnChange() {
+			if Self.syncOnChange {
+				synchronize()
+			}
+		}
+
+		/**
+		Mark the current timestamp for the specified `source`.
+		*/
+		private func recordTimestamp(_ source: DataSource) {
+			switch source {
+			case .local:
+				localStorage.set(Date(), forKey: defaultsSyncKey)
+			case .remote:
+				remoteStorage.set(Date(), forKey: defaultsSyncKey)
+			}
+		}
+
+		/**
+		Determine which data source has the latest data available by comparing the timestamps of the local and remote sources.
+		*/
+		private func latestDataSource() -> DataSource {
+			// If the remote timestamp does not exist, use the local timestamp as the latest data source.
+			guard let remoteTimestamp = remoteStorage.object(forKey: defaultsSyncKey) as? Date else {
+				return .local
+			}
+			guard let localTimestamp = localStorage.object(forKey: defaultsSyncKey) as? Date else {
+				return .remote
+			}
+
+			return localTimestamp.timeIntervalSince1970 > remoteTimestamp.timeIntervalSince1970 ? .local : .remote
+		}
+	}
+}
+
+extension Defaults.iCloud {
+	/**
+	The singleton for Defaults's iCloud.
+	*/
+	static var `default` = Defaults.iCloud()
+
+	/**
+	Lists the synced keys.
+	*/
+	public static let keys = `default`.keys
+
+	/**
+	Enable this if you want to call `NSUbiquitousKeyValueStore.synchronize` when value is changed.
+	*/
+	public static var syncOnChange = false
+
+	/**
+	Enable this if you want to debug the syncing status of keys.
+	*/
+	public static var debug = false
+
+	/**
+	Add keys to be automatically synced.
+	*/
+	public static func add(_ keys: Defaults.Keys...) {
+		`default`.add(keys)
+	}
+
+	/**
+	Remove keys to be automatically synced.
+	*/
+	public static func remove(_ keys: Defaults.Keys...) {
+		`default`.remove(keys)
+	}
+
+	/**
+	Remove all keys to be automatically synced.
+	*/
+	public static func removeAll() {
+		`default`.removeAll()
+	}
+
+	/**
+	Explicitly synchronizes in-memory keys and values with those stored on disk.
+	*/
+	public static func sync() {
+		`default`.synchronize()
+	}
+
+	/**
+	Wait until all synchronization tasks are complete and explicitly synchronizes in-memory keys and values with those stored on disk.
+	*/
+	public static func sync() async {
+		await `default`.backgroundQueue.flush()
+		`default`.synchronize()
+	}
+
+	/**
+	Synchronize all of the keys that have been added to Defaults.iCloud.
+	*/
+	public static func syncKeys() {
+		`default`.syncKeys()
+	}
+
+	/**
+	Synchronize the specified `keys` from the given `source`,  which could be a remote server or a local cache.
+
+	- Parameter keys: The keys that should be synced.
+	- Parameter source: Sync keys from which data source(remote or local)
+
+	- Note: `source` should be specify if `key` has not been added to `Defaults.iCloud`.
+	*/
+	public static func syncKeys(_ keys: Defaults.Keys..., source: DataSource? = nil) {
+		`default`.syncKeys(keys, source)
+	}
+}
+
+/**
+`Defaults.iCloud` notification related functions.
+*/
+extension Defaults.iCloud {
+	private func registerNotifications() {
+		NotificationCenter.default.addObserver(self, selector: #selector(didChangeExternally(notification:)), name: NSUbiquitousKeyValueStore.didChangeExternallyNotification, object: nil)
+		#if os(iOS) || os(tvOS)
+		NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(notification:)), name: UIScene.willEnterForegroundNotification, object: nil)
+		#endif
+		#if os(watchOS)
+		NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(notification:)), name: WKExtension.applicationWillEnterForegroundNotification, object: nil)
+		#endif
+	}
+
+	@objc
+	private func willEnterForeground(notification: Notification) {
+		remoteStorage.synchronize()
+	}
+
+	@objc
+	private func didChangeExternally(notification: Notification) {
+		guard notification.name == NSUbiquitousKeyValueStore.didChangeExternallyNotification else {
+			return
+		}
+
+		guard
+			let userInfo = notification.userInfo,
+			let changedKeys = userInfo[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String],
+			let remoteTimestamp = remoteStorage.object(forKey: defaultsSyncKey) as? Date
+		else {
+			return
+		}
+
+		if
+			let localTimestamp = localStorage.object(forKey: defaultsSyncKey) as? Date,
+			localTimestamp > remoteTimestamp
+		{
+			return
+		}
+
+		for key in self.keys where changedKeys.contains(key.name) {
+			backgroundQueue.sync {
+				await self.syncKey(key, .remote)
+			}
+		}
+	}
+}
+
+/**
+`Defaults.iCloud` observation related functions.
+*/
+extension Defaults.iCloud {
+	private func addObserver(_ key: Defaults.Keys) {
+		backgroundQueue.sync {
+			key.suite.addObserver(self, forKeyPath: key.name, options: [.new], context: nil)
+		}
+	}
+
+	private func removeObserver(_ key: Defaults.Keys) {
+		backgroundQueue.sync {
+			key.suite.removeObserver(self, forKeyPath: key.name, context: nil)
+		}
+	}
+
+	@_documentation(visibility: private)
+	// swiftlint:disable:next block_based_kvo
+	override public func observeValue(
+		forKeyPath keyPath: String?,
+		of object: Any?,
+		change: [NSKeyValueChangeKey: Any]?, // swiftlint:disable:this discouraged_optional_collection
+		context: UnsafeMutableRawPointer?
+	) {
+		guard
+			let keyPath,
+			let object,
+			object is UserDefaults,
+			let key = keys.first(where: { $0.name == keyPath }),
+			!atomicSet.contains(key)
+		else {
+			return
+		}
+
+		backgroundQueue.async {
+			self.recordTimestamp(.local)
+			await self.syncKey(key, .local)
+		}
+	}
+}
+
+/**
+`Defaults.iCloud` logging related functions.
+*/
+extension Defaults.iCloud {
+	private static func logKeySyncStatus(_ key: Defaults.Keys, _ source: DataSource, _ syncStatus: SyncStatus, _ value: Any? = nil) {
+		guard Self.debug else {
+			return
+		}
+		var destination: String
+		switch source {
+		case .local:
+			destination = "from local"
+		case .remote:
+			destination = "from remote"
+		}
+		var status: String
+		var valueDescription = ""
+		switch syncStatus {
+		case .start:
+			status = "Start synchronization"
+		case .isSyncing:
+			status = "Synchronizing"
+			valueDescription = "with value '\(value ?? "nil")'"
+		case .finish:
+			status = "Finish synchronization"
+		}
+		let message = "\(status) key '\(key.name)' \(valueDescription) \(destination)"
+
+		log(message)
+	}
+
+	private static func log(_ message: String) {
+		guard Self.debug else {
+			return
+		}
+		let formatter = DateFormatter()
+		formatter.dateFormat = "y/MM/dd H:mm:ss.SSSS"
+		print("[\(formatter.string(from: Date()))] DEBUG(Defaults) - \(message)")
+	}
+}

--- a/Sources/Defaults/Defaults+iCloud.swift
+++ b/Sources/Defaults/Defaults+iCloud.swift
@@ -392,15 +392,14 @@ extension Defaults.iCloudSynchronizer {
 			return
 		}
 
-		var destination: String
-		switch source {
+		let destination = switch source {
 		case .local:
-			destination = "from local"
+			"from local"
 		case .remote:
-			destination = "from remote"
+			"from remote"
 		}
 
-		var status: String
+		let status: String
 		var valueDescription = " "
 		switch syncStatus {
 		case .idle:
@@ -424,9 +423,9 @@ extension Defaults.iCloudSynchronizer {
 		if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
 			logger.debug("[Defaults.iCloud] \(message)")
 		} else {
-#if canImport(OSLog)
+			#if canImport(OSLog)
 			os_log(.debug, log: .default, "[Defaults.iCloud] %@", message)
-#else
+			#else
 			let dateFormatter = DateFormatter()
 			dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSSSSZZZ"
 			let dateString = dateFormatter.string(from: Date())
@@ -435,7 +434,7 @@ extension Defaults.iCloudSynchronizer {
 			var threadID: UInt64 = 0
 			pthread_threadid_np(nil, &threadID)
 			print("\(dateString) \(processName)[\(processIdentifier):\(threadID)] [Defaults.iCloud] \(message)")
-#endif
+			#endif
 		}
 	}
 }

--- a/Sources/Defaults/Defaults+iCloud.swift
+++ b/Sources/Defaults/Defaults+iCloud.swift
@@ -1,28 +1,11 @@
-#if canImport(OSLog)
 import OSLog
-#endif
-#if !os(macOS)
-import UIKit
-#else
+#if os(macOS)
 import AppKit
+#else
+import UIKit
 #endif
 import Combine
 import Foundation
-
-/**
-Represent different data sources available for synchronization.
-*/
-public enum DataSource {
-	/**
-	Using `key.suite` as data source.
-	*/
-	case local
-
-	/**
-	Using `NSUbiquitousKeyValueStore` as data source.
-	*/
-	case remote
-}
 
 private enum SyncStatus {
 	case idle
@@ -30,287 +13,285 @@ private enum SyncStatus {
 	case completed
 }
 
-extension Defaults {
+/**
+Manages `Defaults.Keys` between the locale and remote storage.
+
+Depending on the storage, `Defaults.Keys` will be represented in different forms due to storage limitations of the remote storage. The remote storage imposes a limitation of 1024 keys. Therefore, we combine the recorded timestamp and data into a single key. Unlike remote storage, local storage does not have this limitation. Therefore, we can create a separate key (with `defaultsSyncKey` suffix) for the timestamp record.
+*/
+final class iCloudSynchronizer {
+	init(remoteStorage: DefaultsKeyValueStore) {
+		self.remoteStorage = remoteStorage
+		registerNotifications()
+		remoteStorage.synchronize()
+	}
+
+	deinit {
+		removeAll()
+	}
+
+	@TaskLocal static var timestamp: Date?
+
+	private var cancellables: Set<AnyCancellable> = []
+
 	/**
-	Manages `Defaults.Keys` between the locale and remote storage.
-
-	Depending on the storage, `Defaults.Keys` will be represented in different forms due to storage limitations of the remote storage. The remote storage imposes a limitation of 1024 keys. Therefore, we combine the recorded timestamp and data into a single key. Unlike remote storage, local storage does not have this limitation. Therefore, we can create a separate key (with `defaultsSyncKey` suffix) for the timestamp record.
+	Key for recording the synchronization between `NSUbiquitousKeyValueStore` and `UserDefaults`.
 	*/
-	public final class iCloudSynchronizer {
-		init(remoteStorage: KeyValueStore) {
-			self.remoteStorage = remoteStorage
-			registerNotifications()
-			remoteStorage.synchronize()
+	private let defaultsSyncKey = "__DEFAULTS__synchronizeTimestamp"
+
+	/**
+	A remote key value storage.
+	*/
+	private let remoteStorage: DefaultsKeyValueStore
+
+	/**
+	A FIFO queue used to serialize synchronization on keys.
+	*/
+	private let backgroundQueue = TaskQueue(priority: .utility)
+
+	/**
+	A thread-safe `keys` that manage the keys to be synced.
+	*/
+	@Atomic(value: []) private(set) var keys: Set<Defaults.Keys>
+
+	/**
+	A thread-safe synchronization status monitor for `keys`.
+	*/
+	@Atomic(value: []) private var remoteSyncingKeys: Set<Defaults.Keys>
+
+	// TODO: Replace it with async stream when Swift supports custom executors.
+	private lazy var localKeysMonitor: Defaults.CompositeUserDefaultsAnyKeyObservation = .init { [weak self] observable in
+		guard
+			let self,
+			let suite = observable.suite,
+			let key = self.keys.first(where: { $0.name == observable.key && $0.suite == suite }),
+			// Prevent triggering local observation when syncing from remote.
+			!self.remoteSyncingKeys.contains(key)
+		else {
+			return
 		}
 
-		deinit {
-			removeAll()
+		self.enqueue {
+			self.recordTimestamp(forKey: key, timestamp: Self.timestamp, source: .local)
+			await self.syncKey(key: key, .local)
 		}
+	}
 
-		@TaskLocal static var timestamp: Date?
+	/**
+	Add new key and start to observe its changes.
+	*/
+	func add(_ keys: [Defaults.Keys]) {
+		self.keys.formUnion(keys)
+		self.syncWithoutWaiting(keys)
+		for key in keys {
+			localKeysMonitor.addObserver(key)
+		}
+	}
 
-		private var cancellables: Set<AnyCancellable> = []
+	/**
+	Remove key and stop the observation.
+	*/
+	func remove(_ keys: [Defaults.Keys]) {
+		self.keys.subtract(keys)
+		for key in keys {
+			localKeysMonitor.removeObserver(key)
+		}
+	}
 
-		/**
-		Key for recording the synchronization between `NSUbiquitousKeyValueStore` and `UserDefaults`.
-		*/
-		private let defaultsSyncKey = "__DEFAULTS__synchronizeTimestamp"
+	/**
+	Remove all sync keys.
+	*/
+	func removeAll() {
+		localKeysMonitor.invalidate()
+		_keys.modify { $0.removeAll() }
+		_remoteSyncingKeys.modify { $0.removeAll() }
+	}
 
-		/**
-		A remote key value storage.
-		*/
-		private var remoteStorage: KeyValueStore
+	/**
+	Explicitly synchronizes in-memory keys and values with those stored on disk.
+	*/
+	func synchronize() {
+		remoteStorage.synchronize()
+	}
 
-		/**
-		A FIFO queue used to serialize synchronization on keys.
-		*/
-		private let backgroundQueue = TaskQueue(priority: .background)
+	/**
+	Synchronize the specified `keys` from the given `source` without waiting.
 
-		/**
-		A thread-safe `keys` that manage the keys to be synced.
-		*/
-		@Atomic(value: []) private(set) var keys: Set<Defaults.Keys>
+	- Parameter keys: If the keys parameter is an empty array, the method will use the keys that were added to `Defaults.iCloud`.
+	- Parameter source: Sync keys from which data source (remote or local).
+	*/
+	func syncWithoutWaiting(_ keys: [Defaults.Keys] = [], _ source: Defaults.DataSource? = nil) {
+		let keys = keys.isEmpty ? Array(self.keys) : keys
 
-		/**
-		A thread-safe synchronization status monitor for `keys`.
-		*/
-		@Atomic(value: []) private var remoteSyncingKeys: Set<Defaults.Keys>
-
-		// TODO: Replace it with async stream when Swift supports custom executors.
-		private lazy var localKeysMonitor: CompositeUserDefaultsAnyKeyObservation = .init { [weak self] observable in
-			guard
-				let self,
-				let suite = observable.suite,
-				let key = self.keys.first(where: { $0.name == observable.key && $0.suite == suite }),
-				// Prevent triggering local observation when syncing from remote.
-				!self.remoteSyncingKeys.contains(key)
-			else {
-				return
-			}
-
+		for key in keys {
+			let latest = source ?? latestDataSource(forKey: key)
 			self.enqueue {
-				self.recordTimestamp(forKey: key, timestamp: Self.timestamp, source: .local)
-				await self.syncKey(forKey: key, .local)
+				await self.syncKey(key: key, latest)
 			}
 		}
+	}
 
-		/**
-		Add new key and start to observe its changes.
-		*/
-		func add(_ keys: [Defaults.Keys]) {
-			self.keys.formUnion(keys)
-			self.syncWithoutWaiting(keys)
-			for key in keys {
-				localKeysMonitor.addObserver(key)
+	/**
+	Wait until all synchronization tasks are complete.
+	*/
+	func sync() async {
+		await backgroundQueue.flush()
+	}
+
+	/**
+	Enqueue the synchronization task into `backgroundQueue` with the current timestamp.
+	*/
+	private func enqueue(_ task: @escaping TaskQueue.AsyncTask) {
+		self.backgroundQueue.async {
+			await Self.$timestamp.withValue(Date()) {
+				await task()
 			}
 		}
+	}
 
-		/**
-		Remove key and stop the observation.
-		*/
-		func remove(_ keys: [Defaults.Keys]) {
-			self.keys.subtract(keys)
-			for key in keys {
-				localKeysMonitor.removeObserver(key)
-			}
+	/**
+	Create synchronization tasks for the specified `key` from the given source.
+
+	- Parameter key: The key to synchronize.
+	- Parameter source: Sync key from which data source (remote or local).
+	*/
+	private func syncKey(key: Defaults.Keys, _ source: Defaults.DataSource) async {
+		Self.logKeySyncStatus(key, source: source, syncStatus: .idle)
+
+		switch source {
+		case .remote:
+			await syncFromRemote(forKey: key)
+		case .local:
+			syncFromLocal(forKey: key)
 		}
 
-		/**
-		Remove all sync keys.
-		*/
-		func removeAll() {
-			localKeysMonitor.invalidate()
-			_keys.modify { $0.removeAll() }
-			_remoteSyncingKeys.modify { $0.removeAll() }
-		}
+		Self.logKeySyncStatus(key, source: source, syncStatus: .completed)
+	}
 
-		/**
-		Explicitly synchronizes in-memory keys and values with those stored on disk.
-		*/
-		func synchronize() {
-			remoteStorage.synchronize()
-		}
+	/**
+	Only update the value if it can be retrieved from the remote storage.
+	*/
+	private func syncFromRemote(forKey key: Defaults.Keys) async {
+		_remoteSyncingKeys.modify { $0.insert(key) }
 
-		/**
-		Synchronize the specified `keys` from the given `source` without waiting.
-
-		- Parameter keys: If the keys parameter is an empty array, the method will use the keys that were added to `Defaults.iCloudSynchronizer`.
-		- Parameter source: Sync keys from which data source (remote or local).
-		*/
-		func syncWithoutWaiting(_ keys: [Defaults.Keys] = [], _ source: DataSource? = nil) {
-			let keys = keys.isEmpty ? Array(self.keys) : keys
-
-			for key in keys {
-				let latest = source ?? latestDataSource(forKey: key)
-				self.enqueue {
-					await self.syncKey(forKey: key, latest)
-				}
-			}
-		}
-
-		/**
-		Wait until all synchronization tasks are complete.
-		*/
-		func sync() async {
-			await backgroundQueue.flush()
-		}
-
-		/**
-		Enqueue the synchronization task into `backgroundQueue` with the current timestamp.
-		*/
-		private func enqueue(_ task: @escaping TaskQueue.AsyncTask) {
-			self.backgroundQueue.async {
-				await Self.$timestamp.withValue(Date()) {
-					await task()
-				}
-			}
-		}
-
-		/**
-		Create synchronization tasks for the specified `key` from the given source.
-
-		- Parameter forKey: The key to synchronize.
-		- Parameter source: Sync key from which data source (remote or local).
-		*/
-		private func syncKey(forKey key: Defaults.Keys, _ source: DataSource) async {
-			Self.logKeySyncStatus(key, source: source, syncStatus: .idle)
-
-			switch source {
-			case .remote:
-				await syncFromRemote(forKey: key)
-			case .local:
-				syncFromLocal(forKey: key)
-			}
-
-			Self.logKeySyncStatus(key, source: source, syncStatus: .completed)
-		}
-
-		/**
-		Only update the value if it can be retrieved from the remote storage.
-		*/
-		private func syncFromRemote(forKey key: Defaults.Keys) async {
-			_remoteSyncingKeys.modify { $0.insert(key) }
-
-			await withCheckedContinuation { continuation in
-				guard
-					let object = remoteStorage.object(forKey: key.name) as? [Any],
-					let date = Self.timestamp,
-					let value = object[safe: 1]
-				else {
-					continuation.resume()
-					return
-				}
-
-				Task { @MainActor in
-					Self.logKeySyncStatus(key, source: .remote, syncStatus: .syncing, value: value)
-					key.suite.set(value, forKey: key.name)
-					key.suite.set(date, forKey: "\(key.name)\(defaultsSyncKey)")
-					continuation.resume()
-				}
-			}
-
-			_remoteSyncingKeys.modify { $0.remove(key) }
-		}
-
-		/**
-		Retrieve a value from local storage, and if it does not exist, remove it from the remote storage.
-		*/
-		private func syncFromLocal(forKey key: Defaults.Keys) {
+		await withCheckedContinuation { continuation in
 			guard
-				let value = key.suite.object(forKey: key.name),
-				let date = Self.timestamp
+				let object = remoteStorage.object(forKey: key.name) as? [Any],
+				let date = Self.timestamp,
+				let value = object[safe: 1]
 			else {
-				Self.logKeySyncStatus(key, source: .local, syncStatus: .syncing, value: nil)
-				remoteStorage.removeObject(forKey: key.name)
-				syncRemoteStorageOnChange()
+				continuation.resume()
 				return
 			}
 
-			Self.logKeySyncStatus(key, source: .local, syncStatus: .syncing, value: value)
-			remoteStorage.set([date, value], forKey: key.name)
+			Task { @MainActor in
+				Self.logKeySyncStatus(key, source: .remote, syncStatus: .syncing, value: value)
+				key.suite.set(value, forKey: key.name)
+				key.suite.set(date, forKey: "\(key.name)\(defaultsSyncKey)")
+				continuation.resume()
+			}
+		}
+
+		_remoteSyncingKeys.modify { $0.remove(key) }
+	}
+
+	/**
+	Retrieve a value from local storage, and if it does not exist, remove it from the remote storage.
+	*/
+	private func syncFromLocal(forKey key: Defaults.Keys) {
+		guard
+			let value = key.suite.object(forKey: key.name),
+			let date = Self.timestamp
+		else {
+			Self.logKeySyncStatus(key, source: .local, syncStatus: .syncing, value: nil)
+			remoteStorage.removeObject(forKey: key.name)
 			syncRemoteStorageOnChange()
+			return
 		}
 
-		/**
-		Explicitly synchronizes in-memory keys and values when a value is changed.
-		*/
-		private func syncRemoteStorageOnChange() {
-			if Defaults.iCloud.syncOnChange {
-				synchronize()
+		Self.logKeySyncStatus(key, source: .local, syncStatus: .syncing, value: value)
+		remoteStorage.set([date, value], forKey: key.name)
+		syncRemoteStorageOnChange()
+	}
+
+	/**
+	Explicitly synchronizes in-memory keys and values when a value is changed.
+	*/
+	private func syncRemoteStorageOnChange() {
+		if Defaults.iCloud.syncOnChange {
+			synchronize()
+		}
+	}
+
+	/**
+	Retrieve the timestamp associated with the specified key from the source provider.
+
+	The timestamp storage format varies across different source providers due to storage limitations.
+	*/
+	private func timestamp(forKey key: Defaults.Keys, _ source: Defaults.DataSource) -> Date? {
+		switch source {
+		case .remote:
+			guard
+				let values = remoteStorage.object(forKey: key.name) as? [Any],
+				let timestamp = values[safe: 0] as? Date
+			else {
+				return nil
 			}
+
+			return timestamp
+		case .local:
+			guard
+				let timestamp = key.suite.object(forKey: "\(key.name)\(defaultsSyncKey)") as? Date
+			else {
+				return nil
+			}
+
+			return timestamp
+		}
+	}
+
+	/**
+	Mark the current timestamp to the given storage.
+	*/
+	func recordTimestamp(forKey key: Defaults.Keys, timestamp: Date?, source: Defaults.DataSource) {
+		switch source {
+		case .remote:
+			guard
+				let values = remoteStorage.object(forKey: key.name) as? [Any],
+				let data = values[safe: 1],
+				let timestamp
+			else {
+				return
+			}
+
+			remoteStorage.set([timestamp, data], forKey: key.name)
+		case .local:
+			guard let timestamp else {
+				return
+			}
+			key.suite.set(timestamp, forKey: "\(key.name)\(defaultsSyncKey)")
+		}
+	}
+
+	/**
+	Determine which data source has the latest data available by comparing the timestamps of the local and remote sources.
+	*/
+	private func latestDataSource(forKey key: Defaults.Keys) -> Defaults.DataSource {
+		// If the remote timestamp does not exist, use the local timestamp as the latest data source.
+		guard let remoteTimestamp = self.timestamp(forKey: key, .remote) else {
+			return .local
+		}
+		guard let localTimestamp = self.timestamp(forKey: key, .local) else {
+			return .remote
 		}
 
-		/**
-		Retrieve the timestamp associated with the specified key from the source provider.
-
-		The timestamp storage format varies across different source providers due to storage limitations.
-		*/
-		private func timestamp(forKey key: Defaults.Keys, _ source: DataSource) -> Date? {
-			switch source {
-			case .remote:
-				guard
-					let values = remoteStorage.object(forKey: key.name) as? [Any],
-					let timestamp = values[safe: 0] as? Date
-				else {
-					return nil
-				}
-
-				return timestamp
-			case .local:
-				guard
-					let timestamp = key.suite.object(forKey: "\(key.name)\(defaultsSyncKey)") as? Date
-				else {
-					return nil
-				}
-
-				return timestamp
-			}
-		}
-
-		/**
-		Mark the current timestamp to the given storage.
-		*/
-		func recordTimestamp(forKey key: Defaults.Keys, timestamp: Date?, source: DataSource) {
-			switch source {
-			case .remote:
-				guard
-					let values = remoteStorage.object(forKey: key.name) as? [Any],
-					let data = values[safe: 1],
-					let timestamp
-				else {
-					return
-				}
-
-				remoteStorage.set([timestamp, data], forKey: key.name)
-			case .local:
-				guard let timestamp else {
-					return
-				}
-				key.suite.set(timestamp, forKey: "\(key.name)\(defaultsSyncKey)")
-			}
-		}
-
-		/**
-		Determine which data source has the latest data available by comparing the timestamps of the local and remote sources.
-		*/
-		private func latestDataSource(forKey key: Defaults.Keys) -> DataSource {
-			// If the remote timestamp does not exist, use the local timestamp as the latest data source.
-			guard let remoteTimestamp = self.timestamp(forKey: key, .remote) else {
-				return .local
-			}
-			guard let localTimestamp = self.timestamp(forKey: key, .local) else {
-				return .remote
-			}
-
-			return localTimestamp > remoteTimestamp ? .local : .remote
-		}
+		return localTimestamp > remoteTimestamp ? .local : .remote
 	}
 }
 
 /**
-`Defaults.iCloudSynchronizer` notification related functions.
+`iCloudSynchronizer` notification related functions.
 */
-extension Defaults.iCloudSynchronizer {
+extension iCloudSynchronizer {
 	private func registerNotifications() {
 		// TODO: Replace it with async stream when Swift supports custom executors.
 		NotificationCenter.default
@@ -374,20 +355,20 @@ extension Defaults.iCloudSynchronizer {
 			}
 
 			self.enqueue {
-				await self.syncKey(forKey: key, .remote)
+				await self.syncKey(key: key, .remote)
 			}
 		}
 	}
 }
 
 /**
-`Defaults.iCloud` logging related functions.
+`iCloudSynchronizer` logging related functions.
 */
-extension Defaults.iCloudSynchronizer {
+extension iCloudSynchronizer {
 	@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 	private static let logger = Logger(OSLog.default)
 
-	private static func logKeySyncStatus(_ key: Defaults.Keys, source: DataSource, syncStatus: SyncStatus, value: Any? = nil) {
+	private static func logKeySyncStatus(_ key: Defaults.Keys, source: Defaults.DataSource, syncStatus: SyncStatus, value: Any? = nil) {
 		guard Defaults.iCloud.isDebug else {
 			return
 		}
@@ -441,51 +422,81 @@ extension Defaults.iCloudSynchronizer {
 
 extension Defaults {
 	/**
-	Automatically create synchronization tasks when the added keys changed.
+	Represent different data sources available for synchronization.
+	*/
+	public enum DataSource {
+		/**
+		Using `key.suite` as data source.
+		*/
+		case local
+
+		/**
+		Using `NSUbiquitousKeyValueStore` as data source.
+		*/
+		case remote
+	}
+
+	/**
+	Synchronize values with different devices over iCloud.
 
 	There are four ways to initiate synchronization, each of which will create a task in `backgroundQueue`:
 
-	1. Using ``add(_:)``
-	2. Utilizing ``syncWithoutWaiting(_:source:)``
-	3. Observing UserDefaults for added `Defaults.Keys` using Key-Value Observation (KVO)
-	4. Monitoring `NSUbiquitousKeyValueStore.didChangeExternallyNotification` for added `Defaults.Keys`.
+	1. Using ``iCloud/add(_:)-5gffb``
+	2. Utilizing ``iCloud/syncWithoutWaiting(_:source:)-9cpju``
+	3. Observing UserDefaults for added ``Defaults/Defaults/Key`` using Key-Value Observation (KVO)
+	4. Monitoring `NSUbiquitousKeyValueStore.didChangeExternallyNotification` for added ``Defaults/Defaults/Key``.
 
-	> Tip: After initializing the task, we can call ``sync()`` to ensure that all tasks in the backgroundQueue are completed.
+	> Tip: After initializing the task, we can call ``iCloud/sync()`` to ensure that all tasks in the backgroundQueue are completed.
 
 	```swift
-	let quality = Defaults.Key<Int>("quality", default: 0, iCloud: true)
-	await Defaults.iCloud.sync()
-	print(NSUbiquitousKeyValueStore.default.object(forKey: quality.name)) //=> 0
-	Defaults[quality] = 1
-	await Defaults.iCloud.sync()
-	print(NSUbiquitousKeyValueStore.default.object(forKey: quality.name)) //=> 1
+	import Defaults
+
+	extension Defaults.Keys {
+		static let isUnicornMode = Key<Bool>("isUnicornMode", default: true, iCloud: true)
+	}
+
+	Task {
+		let quality = Defaults.Key<Int>("quality", default: 0)
+		Defaults.iCloud.add(quality)
+		await Defaults.iCloud.sync() // Using sync to make sure all synchronization tasks are done.
+		// Both `isUnicornMode` and `quality` are synced.
+	}
 	```
 	*/
 	public enum iCloud {
 		/**
 		The singleton for Defaults's iCloudSynchronizer.
 		*/
-		static var synchronizer = Defaults.iCloudSynchronizer(remoteStorage: NSUbiquitousKeyValueStore.default)
+		static var synchronizer = iCloudSynchronizer(remoteStorage: NSUbiquitousKeyValueStore.default)
 
 		/**
 		Lists the synced keys.
 		*/
-		public static let keys = synchronizer.keys
+		public static var keys: Set<Defaults.Keys> { synchronizer.keys }
 
 		/**
-		Enable this if you want to call `NSUbiquitousKeyValueStore.synchronize` when a value is changed.
+		Enable this if you want to call ```` when a value is changed.
 		*/
 		public static var syncOnChange = false
 
 		/**
 		Enable this if you want to debug the syncing status of keys.
+
+		- Note: The log information will include details such as the key being synced, its corresponding value, and the status of the synchronization.
 		*/
 		public static var isDebug = false
 
 		/**
-		Add the keys to be automatically synced and create a synchronization task.
+		Add the keys to be automatically synced.
 		*/
 		public static func add(_ keys: Defaults.Keys...) {
+			synchronizer.add(keys)
+		}
+
+		/**
+		Add the keys to be automatically synced.
+		*/
+		public static func add(_ keys: [Defaults.Keys]) {
 			synchronizer.add(keys)
 		}
 
@@ -493,6 +504,13 @@ extension Defaults {
 		Remove the keys that are set to be automatically synced.
 		*/
 		public static func remove(_ keys: Defaults.Keys...) {
+			synchronizer.remove(keys)
+		}
+
+		/**
+		Remove the keys that are set to be automatically synced.
+		*/
+		public static func remove(_ keys: [Defaults.Keys]) {
 			synchronizer.remove(keys)
 		}
 
@@ -505,20 +523,22 @@ extension Defaults {
 
 		/**
 		Explicitly synchronizes in-memory keys and values with those stored on disk.
+
+		As per apple docs, the only recommended time to call this method is upon app launch, or upon returning to the foreground, to ensure that the in-memory key-value store representation is up-to-date.
 		*/
 		public static func synchronize() {
 			synchronizer.synchronize()
 		}
 
 		/**
-		Wait until all synchronization tasks are complete.
+		Wait until synchronization is complete.
 		*/
 		public static func sync() async {
 			await synchronizer.sync()
 		}
 
 		/**
-		Create synchronization tasks for all the keys that have been added to the `Defaults.iCloud`.
+		Create synchronization tasks for all the keys that have been added to the ``Defaults/Defaults/iCloud``.
 		*/
 		public static func syncWithoutWaiting() {
 			synchronizer.syncWithoutWaiting()
@@ -530,9 +550,21 @@ extension Defaults {
 		- Parameter keys: The keys that should be synced.
 		- Parameter source: Sync keys from which data source(remote or local)
 
-		- Note: `source` should be specify if `key` has not been added to `Defaults.iCloud`.
+		- Note: `source` should be specified if `key` has not been added to ``Defaults/Defaults/iCloud``.
 		*/
 		public static func syncWithoutWaiting(_ keys: Defaults.Keys..., source: DataSource? = nil) {
+			synchronizer.syncWithoutWaiting(keys, source)
+		}
+
+		/**
+		Create synchronization tasks for the specified `keys` from the given source, which can be either a remote server or a local cache.
+
+		- Parameter keys: The keys that should be synced.
+		- Parameter source: Sync keys from which data source(remote or local)
+
+		- Note: `source` should be specified if `key` has not been added to ``Defaults/Defaults/iCloud``.
+		*/
+		public static func syncWithoutWaiting(_ keys: [Defaults.Keys], source: DataSource? = nil) {
 			synchronizer.syncWithoutWaiting(keys, source)
 		}
 	}

--- a/Sources/Defaults/Defaults+iCloud.swift
+++ b/Sources/Defaults/Defaults+iCloud.swift
@@ -365,7 +365,7 @@ extension iCloudSynchronizer {
 `iCloudSynchronizer` logging related functions.
 */
 extension iCloudSynchronizer {
-	@available(macOS 11, iOS 14, tvOS 14, watchOS 7, visionOS 1, *)
+	@available(macOS 11, iOS 14, tvOS 14, watchOS 7, visionOS 1.0, *)
 	private static let logger = Logger(OSLog.default)
 
 	private static func logKeySyncStatus(_ key: Defaults.Keys, source: Defaults.DataSource, syncStatus: SyncStatus, value: Any? = nil) {
@@ -401,7 +401,7 @@ extension iCloudSynchronizer {
 			return
 		}
 
-		if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+		if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, visionOS 1.0, *) {
 			logger.debug("[Defaults.iCloud] \(message)")
 		} else {
 			#if canImport(OSLog)

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -116,7 +116,7 @@ extension Defaults {
 			self.defaultValueGetter = { defaultValue }
 
 			super.init(name: name, suite: suite)
-			
+
 			if iCloud {
 				Defaults.iCloud.add(self)
 			}

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -307,7 +307,9 @@ extension Defaults {
 
 	public typealias RangeSerializable = _DefaultsRange & _DefaultsSerializable
 
-	public typealias KeyValueStore = _DefaultsKeyValueStore
+	typealias KeyValueStore = _DefaultsKeyValueStore
+
+	typealias LockProtocol = _DefaultsLockProtocol
 
 	/**
 	Convenience protocol for `Codable`.

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -110,11 +110,16 @@ extension Defaults {
 		public init(
 			_ name: String,
 			default defaultValue: Value,
-			suite: UserDefaults = .standard
+			suite: UserDefaults = .standard,
+			iCloud: Bool = false
 		) {
 			self.defaultValueGetter = { defaultValue }
 
 			super.init(name: name, suite: suite)
+			
+			if iCloud {
+				Defaults.iCloud.add(self)
+			}
 
 			if (defaultValue as? _DefaultsOptionalProtocol)?._defaults_isNil == true {
 				return
@@ -147,11 +152,16 @@ extension Defaults {
 		public init(
 			_ name: String,
 			suite: UserDefaults = .standard,
-			default defaultValueGetter: @escaping () -> Value
+			default defaultValueGetter: @escaping () -> Value,
+			iCloud: Bool = false
 		) {
 			self.defaultValueGetter = defaultValueGetter
 
 			super.init(name: name, suite: suite)
+
+			if iCloud {
+				Defaults.iCloud.add(self)
+			}
 		}
 	}
 }
@@ -163,12 +173,12 @@ extension Defaults.Key {
 
 	- Parameter name: The name must be ASCII, not start with `@`, and cannot contain a dot (`.`).
 	*/
-	@_transparent
 	public convenience init<T>(
 		_ name: String,
-		suite: UserDefaults = .standard
+		suite: UserDefaults = .standard,
+		iCloud: Bool = false
 	) where Value == T? {
-		self.init(name, default: nil, suite: suite)
+		self.init(name, default: nil, suite: suite, iCloud: iCloud)
 	}
 }
 
@@ -296,6 +306,8 @@ extension Defaults {
 	public typealias Bridge = _DefaultsBridge
 
 	public typealias RangeSerializable = _DefaultsRange & _DefaultsSerializable
+
+	public typealias KeyValueStore = _DefaultsKeyValueStore
 
 	/**
 	Convenience protocol for `Codable`.

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -103,6 +103,7 @@ extension Defaults {
 		Create a key.
 
 		- Parameter name: The name must be ASCII, not start with `@`, and cannot contain a dot (`.`).
+		- Parameter iCloud: Set `true` if you want automatic synchronization to iCloud.
 
 		The `default` parameter should not be used if the `Value` type is an optional.
 		*/
@@ -308,10 +309,6 @@ extension Defaults {
 	public typealias Bridge = _DefaultsBridge
 
 	public typealias RangeSerializable = _DefaultsRange & _DefaultsSerializable
-
-	typealias KeyValueStore = _DefaultsKeyValueStore
-
-	typealias LockProtocol = _DefaultsLockProtocol
 
 	/**
 	Convenience protocol for `Codable`.

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -103,7 +103,7 @@ extension Defaults {
 		Create a key.
 
 		- Parameter name: The name must be ASCII, not start with `@`, and cannot contain a dot (`.`).
-		- Parameter iCloud: Set `true` if you want automatic synchronization to iCloud.
+		- Parameter iCloud: Automatically synchronize the value with ``Defaults/Defaults/iCloud``.
 
 		The `default` parameter should not be used if the `Value` type is an optional.
 		*/
@@ -148,6 +148,7 @@ extension Defaults {
 		```
 
 		- Parameter name: The name must be ASCII, not start with `@`, and cannot contain a dot (`.`).
+		- Parameter iCloud: Automatically synchronize the value with ``Defaults/Defaults/iCloud``.
 
 		- Note: This initializer will not set the default value in the actual `UserDefaults`. This should not matter much though. It's only really useful if you use legacy KVO bindings.
 		*/
@@ -175,6 +176,7 @@ extension Defaults.Key {
 	Create a key with an optional value.
 
 	- Parameter name: The name must be ASCII, not start with `@`, and cannot contain a dot (`.`).
+	- Parameter iCloud: Automatically synchronize the value with ``Defaults/Defaults/iCloud``.
 	*/
 	public convenience init<T>(
 		_ name: String,

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -113,13 +113,15 @@ extension Defaults {
 			suite: UserDefaults = .standard,
 			iCloud: Bool = false
 		) {
+			defer {
+				if iCloud {
+					Defaults.iCloud.add(self)
+				}
+			}
+
 			self.defaultValueGetter = { defaultValue }
 
 			super.init(name: name, suite: suite)
-
-			if iCloud {
-				Defaults.iCloud.add(self)
-			}
 
 			if (defaultValue as? _DefaultsOptionalProtocol)?._defaults_isNil == true {
 				return

--- a/Sources/Defaults/Documentation.docc/Documentation.md
+++ b/Sources/Defaults/Documentation.docc/Documentation.md
@@ -66,3 +66,7 @@ typealias Default = _Default
 
 - ``Defaults/PreferRawRepresentable``
 - ``Defaults/PreferNSSecureCoding``
+
+### iCloud
+
+- ``Defaults/iCloud``

--- a/Sources/Defaults/SwiftUI.swift
+++ b/Sources/Defaults/SwiftUI.swift
@@ -34,7 +34,7 @@ extension Defaults {
 
 		func observe() {
 			// We only use this on the latest OSes (as of adding this) since the backdeploy library has a lot of bugs.
-			if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+			if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1.0, *) {
 				task?.cancel()
 
 				// The `@MainActor` is important as the `.send()` method doesn't inherit the `@MainActor` from the class.

--- a/Sources/Defaults/Utilities.swift
+++ b/Sources/Defaults/Utilities.swift
@@ -254,7 +254,7 @@ class Lock: DefaultsLockProtocol {
 		}
 	}
 
-	@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+	@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)
 	final class AllocatedUnfairLock: Lock {
 		private let _lock = OSAllocatedUnfairLock()
 
@@ -272,7 +272,7 @@ class Lock: DefaultsLockProtocol {
 	}
 
 	static func make() -> Self {
-		guard #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) else {
+		guard #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *) else {
 			return UnfairLock() as! Self
 		}
 

--- a/Sources/Defaults/Utilities.swift
+++ b/Sources/Defaults/Utilities.swift
@@ -236,7 +236,7 @@ extension Defaults.Serializable {
 }
 
 // swiftlint:disable:next final_class
-class Lock: Defaults.LockProtocol {
+class Lock: DefaultsLockProtocol {
 	final class UnfairLock: Lock {
 		private let _lock: os_unfair_lock_t
 

--- a/Sources/Defaults/Utilities.swift
+++ b/Sources/Defaults/Utilities.swift
@@ -366,6 +366,7 @@ final class TaskQueue {
 	}
 }
 
+// TODO: replace with Swift 6 native Atomics support.
 @propertyWrapper
 final class Atomic<Value> {
 	private let lock: Lock = .make()

--- a/Tests/DefaultsTests/Defaults+iCloudTests.swift
+++ b/Tests/DefaultsTests/Defaults+iCloudTests.swift
@@ -4,29 +4,44 @@ import XCTest
 
 final class MockStorage: Defaults.KeyValueStore {
 	private var pairs: [String: Any] = [:]
+	private let queue = DispatchQueue(label: "a")
 
 	func object<T>(forKey aKey: String) -> T? {
-		pairs[aKey] as? T
+		queue.sync {
+			pairs[aKey] as? T
+		}
 	}
 
 	func object(forKey aKey: String) -> Any? {
-		pairs[aKey]
+		queue.sync {
+			pairs[aKey]
+		}
 	}
 
 	func set(_ anObject: Any?, forKey aKey: String) {
-		pairs[aKey] = anObject
+		queue.sync {
+			pairs[aKey] = anObject
+		}
 	}
 
 	func removeObject(forKey aKey: String) {
-		pairs.removeValue(forKey: aKey)
+		_ = queue.sync {
+			pairs.removeValue(forKey: aKey)
+		}
 	}
 
 	func removeAll() {
-		pairs.removeAll()
+		queue.sync {
+			pairs.removeAll()
+		}
 	}
 
+	@discardableResult
 	func synchronize() -> Bool {
-		NotificationCenter.default.post(Notification(name: NSUbiquitousKeyValueStore.didChangeExternallyNotification, userInfo: [NSUbiquitousKeyValueStoreChangedKeysKey: Array(pairs.keys)]))
+		let pairs = queue.sync {
+			Array(self.pairs.keys)
+		}
+		NotificationCenter.default.post(Notification(name: NSUbiquitousKeyValueStore.didChangeExternallyNotification, userInfo: [NSUbiquitousKeyValueStoreChangedKeysKey: pairs]))
 		return true
 	}
 }
@@ -36,22 +51,21 @@ private let mockStorage = MockStorage()
 @available(iOS 15, tvOS 15, watchOS 8, *)
 final class DefaultsICloudTests: XCTestCase {
 	override class func setUp() {
-		Defaults.iCloud.debug = true
-		Defaults.iCloud.syncOnChange = true
-		Defaults.iCloud.default = Defaults.iCloud(remoteStorage: mockStorage)
+		Defaults.iCloud.isDebug = true
+		Defaults.iCloud.shared = Defaults.iCloudSynchronizer(remoteStorage: mockStorage)
 	}
 
 	override func setUp() {
 		super.setUp()
-		Defaults.iCloud.removeAll()
 		mockStorage.removeAll()
+		Defaults.iCloud.removeAll()
 		Defaults.removeAll()
 	}
 
 	override func tearDown() {
 		super.tearDown()
-		Defaults.iCloud.removeAll()
 		mockStorage.removeAll()
+		Defaults.iCloud.removeAll()
 		Defaults.removeAll()
 	}
 
@@ -79,7 +93,8 @@ final class DefaultsICloudTests: XCTestCase {
 
 		updateMockStorage(key: quality.name, value: 8.0)
 		updateMockStorage(key: name.name, value: "8")
-		_ = mockStorage.synchronize()
+		mockStorage.synchronize()
+		await Defaults.iCloud.sync()
 		XCTAssertEqual(Defaults[quality], 8.0)
 		XCTAssertEqual(Defaults[name], "8")
 
@@ -89,12 +104,10 @@ final class DefaultsICloudTests: XCTestCase {
 		XCTAssertEqual(mockStorage.object(forKey: name.name), "9")
 		XCTAssertEqual(mockStorage.object(forKey: quality.name), 9.0)
 
-		Defaults[name] = "10"
-		Defaults[quality] = 10.0
+		mockStorage.set("10", forKey: name.name)
+		mockStorage.set(10.0, forKey: quality.name)
+		mockStorage.synchronize()
 		await Defaults.iCloud.sync()
-		mockStorage.set("11", forKey: name.name)
-		mockStorage.set(11.0, forKey: quality.name)
-		_ = mockStorage.synchronize()
 		XCTAssertEqual(Defaults[quality], 10.0)
 		XCTAssertEqual(Defaults[name], "10")
 	}
@@ -108,10 +121,11 @@ final class DefaultsICloudTests: XCTestCase {
 		for index in 0..<name_expected.count {
 			updateMockStorage(key: name.name, value: name_expected[index])
 			updateMockStorage(key: quality.name, value: quality_expected[index])
-			_ = mockStorage.synchronize()
-			XCTAssertEqual(Defaults[name], name_expected[index])
-			XCTAssertEqual(Defaults[quality], quality_expected[index])
+			mockStorage.synchronize()
 		}
+		await Defaults.iCloud.sync()
+		XCTAssertEqual(Defaults[name], "7")
+		XCTAssertEqual(Defaults[quality], 7.0)
 
 		Defaults[name] = "8"
 		Defaults[quality] = 8.0
@@ -147,14 +161,18 @@ final class DefaultsICloudTests: XCTestCase {
 	func testRemoveKey() async {
 		let name = Defaults.Key<String>("testRemoveKey_name", default: "0", iCloud: true)
 		let quality = Defaults.Key<Double>("testRemoveKey_quality", default: 0.0, iCloud: true)
-		await Defaults.iCloud.sync()
-
-		Defaults.iCloud.remove(quality)
 		Defaults[name] = "1"
 		Defaults[quality] = 1.0
 		await Defaults.iCloud.sync()
 		XCTAssertEqual(mockStorage.object(forKey: name.name), "1")
-		XCTAssertEqual(mockStorage.object(forKey: quality.name), 0.0)
+		XCTAssertEqual(mockStorage.object(forKey: quality.name), 1.0)
+
+		Defaults.iCloud.remove(quality)
+		Defaults[name] = "2"
+		Defaults[quality] = 1.0
+		await Defaults.iCloud.sync()
+		XCTAssertEqual(mockStorage.object(forKey: name.name), "2")
+		XCTAssertEqual(mockStorage.object(forKey: quality.name), 1.0)
 	}
 
 	func testSyncKeysFromLocal() async {
@@ -162,18 +180,20 @@ final class DefaultsICloudTests: XCTestCase {
 		let quality = Defaults.Key<Double>("testSyncKeysFromLocal_quality", default: 0.0)
 		let name_expected = ["1", "2", "3", "4", "5", "6", "7"]
 		let quality_expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
-
+		NSUbiquitousKeyValueStore.default.object(forKey: quality.name)
 		for index in 0..<name_expected.count {
 			Defaults[name] = name_expected[index]
 			Defaults[quality] = quality_expected[index]
-			Defaults.iCloud.syncKeys(name, quality, source: .local)
+			Defaults.iCloud.syncWithoutWaiting(name, quality, source: .local)
+			await Defaults.iCloud.sync()
 			XCTAssertEqual(mockStorage.object(forKey: name.name), name_expected[index])
 			XCTAssertEqual(mockStorage.object(forKey: quality.name), quality_expected[index])
 		}
 
 		updateMockStorage(key: name.name, value: "8")
 		updateMockStorage(key: quality.name, value: 8)
-		Defaults.iCloud.syncKeys(name, quality, source: .remote)
+		Defaults.iCloud.syncWithoutWaiting(name, quality, source: .remote)
+		await Defaults.iCloud.sync()
 		XCTAssertEqual(Defaults[quality], 8.0)
 		XCTAssertEqual(Defaults[name], "8")
 	}
@@ -187,21 +207,22 @@ final class DefaultsICloudTests: XCTestCase {
 		for index in 0..<name_expected.count {
 			updateMockStorage(key: name.name, value: name_expected[index])
 			updateMockStorage(key: quality.name, value: quality_expected[index])
-			Defaults.iCloud.syncKeys(name, quality, source: .remote)
+			Defaults.iCloud.syncWithoutWaiting(name, quality, source: .remote)
+			await Defaults.iCloud.sync()
 			XCTAssertEqual(Defaults[name], name_expected[index])
 			XCTAssertEqual(Defaults[quality], quality_expected[index])
 		}
 
 		Defaults[name] = "8"
 		Defaults[quality] = 8.0
-		Defaults.iCloud.syncKeys(name, quality, source: .local)
+		Defaults.iCloud.syncWithoutWaiting(name, quality, source: .local)
 		await Defaults.iCloud.sync()
 		XCTAssertEqual(mockStorage.object(forKey: name.name), "8")
 		XCTAssertEqual(mockStorage.object(forKey: quality.name), 8.0)
 
 		Defaults[name] = nil
 		Defaults[quality] = nil
-		Defaults.iCloud.syncKeys(name, quality, source: .local)
+		Defaults.iCloud.syncWithoutWaiting(name, quality, source: .local)
 		await Defaults.iCloud.sync()
 		XCTAssertNil(mockStorage.object(forKey: name.name))
 		XCTAssertNil(mockStorage.object(forKey: quality.name))
@@ -211,11 +232,14 @@ final class DefaultsICloudTests: XCTestCase {
 		let name = Defaults.Key<String>("testInitAddFromDetached_name", default: "0")
 		let task = Task.detached {
 			Defaults.iCloud.add(name)
-			Defaults.iCloud.syncKeys()
+			Defaults.iCloud.syncWithoutWaiting()
 			await Defaults.iCloud.sync()
 		}
 		await task.value
 		XCTAssertEqual(mockStorage.object(forKey: name.name), "0")
+		Defaults[name] = "1"
+		await Defaults.iCloud.sync()
+		XCTAssertEqual(mockStorage.object(forKey: name.name), "1")
 	}
 
 	func testICloudInitializeFromDetached() async {

--- a/Tests/DefaultsTests/Defaults+iCloudTests.swift
+++ b/Tests/DefaultsTests/Defaults+iCloudTests.swift
@@ -52,7 +52,7 @@ private let mockStorage = MockStorage()
 final class DefaultsICloudTests: XCTestCase {
 	override class func setUp() {
 		Defaults.iCloud.isDebug = true
-		Defaults.iCloud.shared = Defaults.iCloudSynchronizer(remoteStorage: mockStorage)
+		Defaults.iCloud.synchronizer = Defaults.iCloudSynchronizer(remoteStorage: mockStorage)
 	}
 
 	override func setUp() {

--- a/Tests/DefaultsTests/Defaults+iCloudTests.swift
+++ b/Tests/DefaultsTests/Defaults+iCloudTests.swift
@@ -1,0 +1,229 @@
+@testable import Defaults
+import SwiftUI
+import XCTest
+
+final class MockStorage: Defaults.KeyValueStore {
+	private var pairs: [String: Any] = [:]
+
+	func object<T>(forKey aKey: String) -> T? {
+		pairs[aKey] as? T
+	}
+
+	func object(forKey aKey: String) -> Any? {
+		pairs[aKey]
+	}
+
+	func set(_ anObject: Any?, forKey aKey: String) {
+		pairs[aKey] = anObject
+	}
+
+	func removeObject(forKey aKey: String) {
+		pairs.removeValue(forKey: aKey)
+	}
+
+	func removeAll() {
+		pairs.removeAll()
+	}
+
+	func synchronize() -> Bool {
+		NotificationCenter.default.post(Notification(name: NSUbiquitousKeyValueStore.didChangeExternallyNotification, userInfo: [NSUbiquitousKeyValueStoreChangedKeysKey: Array(pairs.keys)]))
+		return true
+	}
+}
+
+private let mockStorage = MockStorage()
+
+@available(iOS 15, tvOS 15, watchOS 8, *)
+final class DefaultsICloudTests: XCTestCase {
+	override class func setUp() {
+		Defaults.iCloud.debug = true
+		Defaults.iCloud.syncOnChange = true
+		Defaults.iCloud.default = Defaults.iCloud(remoteStorage: mockStorage)
+	}
+
+	override func setUp() {
+		super.setUp()
+		Defaults.iCloud.removeAll()
+		mockStorage.removeAll()
+		Defaults.removeAll()
+	}
+
+	override func tearDown() {
+		super.tearDown()
+		Defaults.iCloud.removeAll()
+		mockStorage.removeAll()
+		Defaults.removeAll()
+	}
+
+	private func updateMockStorage<T>(key: String, value: T, _ date: Date? = nil) {
+		mockStorage.set(value, forKey: key)
+		mockStorage.set(date ?? Date(), forKey: "__DEFAULTS__synchronizeTimestamp")
+	}
+
+	func testICloudInitialize() async {
+		let name = Defaults.Key<String>("testICloudInitialize_name", default: "0", iCloud: true)
+		let quality = Defaults.Key<Double>("testICloudInitialize_quality", default: 0.0, iCloud: true)
+		await Defaults.iCloud.sync()
+		XCTAssertEqual(mockStorage.object(forKey: name.name), "0")
+		XCTAssertEqual(mockStorage.object(forKey: quality.name), 0.0)
+		let name_expected = ["1", "2", "3", "4", "5", "6", "7"]
+		let quality_expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+
+		for index in 0..<name_expected.count {
+			Defaults[name] = name_expected[index]
+			Defaults[quality] = quality_expected[index]
+			await Defaults.iCloud.sync()
+			XCTAssertEqual(mockStorage.object(forKey: name.name), name_expected[index])
+			XCTAssertEqual(mockStorage.object(forKey: quality.name), quality_expected[index])
+		}
+
+		updateMockStorage(key: quality.name, value: 8.0)
+		updateMockStorage(key: name.name, value: "8")
+		_ = mockStorage.synchronize()
+		XCTAssertEqual(Defaults[quality], 8.0)
+		XCTAssertEqual(Defaults[name], "8")
+
+		Defaults[name] = "9"
+		Defaults[quality] = 9.0
+		await Defaults.iCloud.sync()
+		XCTAssertEqual(mockStorage.object(forKey: name.name), "9")
+		XCTAssertEqual(mockStorage.object(forKey: quality.name), 9.0)
+
+		Defaults[name] = "10"
+		Defaults[quality] = 10.0
+		await Defaults.iCloud.sync()
+		mockStorage.set("11", forKey: name.name)
+		mockStorage.set(11.0, forKey: quality.name)
+		_ = mockStorage.synchronize()
+		XCTAssertEqual(Defaults[quality], 10.0)
+		XCTAssertEqual(Defaults[name], "10")
+	}
+
+	func testDidChangeExternallyNotification() async {
+		let name = Defaults.Key<String?>("testDidChangeExternallyNotification_name", iCloud: true)
+		let quality = Defaults.Key<Double?>("testDidChangeExternallyNotification_quality", iCloud: true)
+		let name_expected = ["1", "2", "3", "4", "5", "6", "7"]
+		let quality_expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+
+		for index in 0..<name_expected.count {
+			updateMockStorage(key: name.name, value: name_expected[index])
+			updateMockStorage(key: quality.name, value: quality_expected[index])
+			_ = mockStorage.synchronize()
+			XCTAssertEqual(Defaults[name], name_expected[index])
+			XCTAssertEqual(Defaults[quality], quality_expected[index])
+		}
+
+		Defaults[name] = "8"
+		Defaults[quality] = 8.0
+		await Defaults.iCloud.sync()
+		XCTAssertEqual(mockStorage.object(forKey: name.name), "8")
+		XCTAssertEqual(mockStorage.object(forKey: quality.name), 8.0)
+
+		Defaults[name] = nil
+		Defaults[quality] = nil
+		await Defaults.iCloud.sync()
+		XCTAssertNil(mockStorage.object(forKey: name.name))
+		XCTAssertNil(mockStorage.object(forKey: quality.name))
+	}
+
+	func testICloudInitializeSyncLast() async {
+		let name = Defaults.Key<String>("testICloudInitializeSyncLast_name", default: "0", iCloud: true)
+		let quality = Defaults.Key<Double>("testICloudInitializeSyncLast_quality", default: 0.0, iCloud: true)
+		let name_expected = ["1", "2", "3", "4", "5", "6", "7"]
+		let quality_expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+
+		for index in 0..<name_expected.count {
+			Defaults[name] = name_expected[index]
+			Defaults[quality] = quality_expected[index]
+			XCTAssertEqual(Defaults[name], name_expected[index])
+			XCTAssertEqual(Defaults[quality], quality_expected[index])
+		}
+
+		await Defaults.iCloud.sync()
+		XCTAssertEqual(mockStorage.object(forKey: name.name), "7")
+		XCTAssertEqual(mockStorage.object(forKey: quality.name), 7.0)
+	}
+
+	func testRemoveKey() async {
+		let name = Defaults.Key<String>("testRemoveKey_name", default: "0", iCloud: true)
+		let quality = Defaults.Key<Double>("testRemoveKey_quality", default: 0.0, iCloud: true)
+		await Defaults.iCloud.sync()
+
+		Defaults.iCloud.remove(quality)
+		Defaults[name] = "1"
+		Defaults[quality] = 1.0
+		await Defaults.iCloud.sync()
+		XCTAssertEqual(mockStorage.object(forKey: name.name), "1")
+		XCTAssertEqual(mockStorage.object(forKey: quality.name), 0.0)
+	}
+
+	func testSyncKeysFromLocal() async {
+		let name = Defaults.Key<String>("testSyncKeysFromLocal_name", default: "0")
+		let quality = Defaults.Key<Double>("testSyncKeysFromLocal_quality", default: 0.0)
+		let name_expected = ["1", "2", "3", "4", "5", "6", "7"]
+		let quality_expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+
+		for index in 0..<name_expected.count {
+			Defaults[name] = name_expected[index]
+			Defaults[quality] = quality_expected[index]
+			Defaults.iCloud.syncKeys(name, quality, source: .local)
+			XCTAssertEqual(mockStorage.object(forKey: name.name), name_expected[index])
+			XCTAssertEqual(mockStorage.object(forKey: quality.name), quality_expected[index])
+		}
+
+		updateMockStorage(key: name.name, value: "8")
+		updateMockStorage(key: quality.name, value: 8)
+		Defaults.iCloud.syncKeys(name, quality, source: .remote)
+		XCTAssertEqual(Defaults[quality], 8.0)
+		XCTAssertEqual(Defaults[name], "8")
+	}
+
+	func testSyncKeysFromRemote() async {
+		let name = Defaults.Key<String?>("testSyncKeysFromRemote_name")
+		let quality = Defaults.Key<Double?>("testSyncKeysFromRemote_quality")
+		let name_expected = ["1", "2", "3", "4", "5", "6", "7"]
+		let quality_expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+
+		for index in 0..<name_expected.count {
+			updateMockStorage(key: name.name, value: name_expected[index])
+			updateMockStorage(key: quality.name, value: quality_expected[index])
+			Defaults.iCloud.syncKeys(name, quality, source: .remote)
+			XCTAssertEqual(Defaults[name], name_expected[index])
+			XCTAssertEqual(Defaults[quality], quality_expected[index])
+		}
+
+		Defaults[name] = "8"
+		Defaults[quality] = 8.0
+		Defaults.iCloud.syncKeys(name, quality, source: .local)
+		await Defaults.iCloud.sync()
+		XCTAssertEqual(mockStorage.object(forKey: name.name), "8")
+		XCTAssertEqual(mockStorage.object(forKey: quality.name), 8.0)
+
+		Defaults[name] = nil
+		Defaults[quality] = nil
+		Defaults.iCloud.syncKeys(name, quality, source: .local)
+		await Defaults.iCloud.sync()
+		XCTAssertNil(mockStorage.object(forKey: name.name))
+		XCTAssertNil(mockStorage.object(forKey: quality.name))
+	}
+
+	func testAddFromDetached() async {
+		let name = Defaults.Key<String>("testInitAddFromDetached_name", default: "0")
+		let task = Task.detached {
+			Defaults.iCloud.add(name)
+			Defaults.iCloud.syncKeys()
+			await Defaults.iCloud.sync()
+		}
+		await task.value
+		XCTAssertEqual(mockStorage.object(forKey: name.name), "0")
+	}
+
+	func testICloudInitializeFromDetached() async {
+		let task = Task.detached {
+			let name = Defaults.Key<String>("testICloudInitializeFromDetached_name", default: "0", iCloud: true)
+			await Defaults.iCloud.sync()
+			XCTAssertEqual(mockStorage.object(forKey: name.name), "0")
+		}
+		await task.value
+	}
+}

--- a/Tests/DefaultsTests/Defaults+iCloudTests.swift
+++ b/Tests/DefaultsTests/Defaults+iCloudTests.swift
@@ -77,6 +77,8 @@ final class DefaultsICloudTests: XCTestCase {
 	func testICloudInitialize() async {
 		let name = Defaults.Key<String>("testICloudInitialize_name", default: "0", iCloud: true)
 		let quality = Defaults.Key<Double>("testICloudInitialize_quality", default: 0.0, iCloud: true)
+		// Not sure why github action will not trigger a observation callback after initialization, cannot reproduce in local.
+		Defaults.iCloud.syncWithoutWaiting()
 		await Defaults.iCloud.sync()
 		XCTAssertEqual(mockStorage.object(forKey: name.name), "0")
 		XCTAssertEqual(mockStorage.object(forKey: quality.name), 0.0)
@@ -180,7 +182,7 @@ final class DefaultsICloudTests: XCTestCase {
 		let quality = Defaults.Key<Double>("testSyncKeysFromLocal_quality", default: 0.0)
 		let name_expected = ["1", "2", "3", "4", "5", "6", "7"]
 		let quality_expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
-		NSUbiquitousKeyValueStore.default.object(forKey: quality.name)
+
 		for index in 0..<name_expected.count {
 			Defaults[name] = name_expected[index]
 			Defaults[quality] = quality_expected[index]
@@ -245,6 +247,8 @@ final class DefaultsICloudTests: XCTestCase {
 	func testICloudInitializeFromDetached() async {
 		let task = Task.detached {
 			let name = Defaults.Key<String>("testICloudInitializeFromDetached_name", default: "0", iCloud: true)
+			// Not sure why github action will not trigger a observation callback after initialization, cannot reproduce in local.
+			Defaults.iCloud.syncWithoutWaiting()
 			await Defaults.iCloud.sync()
 			XCTAssertEqual(mockStorage.object(forKey: name.name), "0")
 		}

--- a/Tests/DefaultsTests/Defaults+iCloudTests.swift
+++ b/Tests/DefaultsTests/Defaults+iCloudTests.swift
@@ -61,7 +61,7 @@ final class MockStorage: DefaultsKeyValueStore {
 
 private let mockStorage = MockStorage()
 
-@available(iOS 15, tvOS 15, watchOS 8, *)
+@available(iOS 15, tvOS 15, watchOS 8, visionOS 1.0, *)
 final class DefaultsICloudTests: XCTestCase {
 	override class func setUp() {
 		Defaults.iCloud.isDebug = true

--- a/Tests/DefaultsTests/Defaults+iCloudTests.swift
+++ b/Tests/DefaultsTests/Defaults+iCloudTests.swift
@@ -63,7 +63,7 @@ private let mockStorage = MockStorage()
 
 @available(iOS 15, tvOS 15, watchOS 8, visionOS 1.0, *)
 final class DefaultsICloudTests: XCTestCase {
-	override class func setUp() {
+	override final class func setUp() {
 		Defaults.iCloud.isDebug = true
 		Defaults.iCloud.syncOnChange = true
 		Defaults.iCloud.synchronizer = iCloudSynchronizer(remoteStorage: mockStorage)

--- a/Tests/DefaultsTests/Defaults+iCloudTests.swift
+++ b/Tests/DefaultsTests/Defaults+iCloudTests.swift
@@ -2,7 +2,7 @@
 import SwiftUI
 import XCTest
 
-final class MockStorage: Defaults.KeyValueStore {
+final class MockStorage: DefaultsKeyValueStore {
 	private var pairs: [String: Any] = [:]
 	private let queue = DispatchQueue(label: "a")
 
@@ -66,7 +66,7 @@ final class DefaultsICloudTests: XCTestCase {
 	override class func setUp() {
 		Defaults.iCloud.isDebug = true
 		Defaults.iCloud.syncOnChange = true
-		Defaults.iCloud.synchronizer = Defaults.iCloudSynchronizer(remoteStorage: mockStorage)
+		Defaults.iCloud.synchronizer = iCloudSynchronizer(remoteStorage: mockStorage)
 	}
 
 	override func setUp() {
@@ -88,9 +88,11 @@ final class DefaultsICloudTests: XCTestCase {
 	}
 
 	func testICloudInitialize() async {
+		print(Defaults.iCloud.keys)
 		let name = Defaults.Key<String>("testICloudInitialize_name", default: "0", iCloud: true)
 		let quality = Defaults.Key<Double>("testICloudInitialize_quality", default: 0.0, iCloud: true)
 
+		print(Defaults.iCloud.keys)
 		await Defaults.iCloud.sync()
 		XCTAssertEqual(mockStorage.data(forKey: name.name), "0")
 		XCTAssertEqual(mockStorage.data(forKey: quality.name), 0.0)

--- a/Tests/DefaultsTests/DefaultsColorTests.swift
+++ b/Tests/DefaultsTests/DefaultsColorTests.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Defaults
 import XCTest
 
-@available(iOS 15, tvOS 15, watchOS 8, *)
+@available(iOS 15, tvOS 15, watchOS 8, visionOS 1.0, *)
 final class DefaultsColorTests: XCTestCase {
 	override func setUp() {
 		super.setUp()

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ It's used in production by [all my apps](https://sindresorhus.com/apps) (1 milli
 - **Observation:** Observe changes to keys.
 - **Debuggable:** The data is stored as JSON-serialized values.
 - **Customizable:** You can serialize and deserialize your own type in your own way.
-- **iCloud support:** You can easily synchronize data among instances of your app.
+- **iCloud support:** Automatically synchronize data between devices.
 
 ## Benefits over `@AppStorage`
 
@@ -333,34 +333,6 @@ print(UserDefaults.standard.bool(forKey: Defaults.Keys.isUnicornMode.name))
 
 > **Note** 
 > A `Defaults.Key` with a dynamic default value will not register the default value in `UserDefaults`.
-
-### Automatically synchronize data with iCloud
-
-You can create an automatically synchronizing `Defaults.Key` by setting the `iCloud` parameter to true.
-
-```swift
-extension Defaults.Keys {
-	static let isUnicornMode = Key<Bool>("isUnicornMode", default: true, iCloud: true)
-}
-
-Task {
-	await Defaults.iCloud.sync() // Using sync to make sure all synchronization tasks are done.
-	print(NSUbiquitousKeyValueStore.default.bool(forKey: Defaults.Keys.isUnicornMode.name))
-	//=> true
-}
-```
-
-Also you can synchronize `Defaults.Key` manually, but make sure you select correct `source`. 
-
-```swift
-extension Defaults.Keys {
-	static let isUnicornMode = Key<Bool>("isUnicornMode", default: true)
-}
-
-Defaults.iCloud.syncKeys(.isUnicornMode, source: .local) // This will synchronize the value of the `isUnicornMode` key from the local source. 
-print(NSUbiquitousKeyValueStore.default.bool(forKey: Defaults.Keys.isUnicornMode.name))
-//=> true
-```
 
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -334,7 +334,6 @@ print(UserDefaults.standard.bool(forKey: Defaults.Keys.isUnicornMode.name))
 > **Note** 
 > A `Defaults.Key` with a dynamic default value will not register the default value in `UserDefaults`.
 
-
 ## API
 
 ### `Defaults`

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ It's used in production by [all my apps](https://sindresorhus.com/apps) (1 milli
 - **Observation:** Observe changes to keys.
 - **Debuggable:** The data is stored as JSON-serialized values.
 - **Customizable:** You can serialize and deserialize your own type in your own way.
+- **iCloud support:** You can easily synchronize data among instances of your app.
 
 ## Benefits over `@AppStorage`
 
@@ -332,6 +333,35 @@ print(UserDefaults.standard.bool(forKey: Defaults.Keys.isUnicornMode.name))
 
 > **Note** 
 > A `Defaults.Key` with a dynamic default value will not register the default value in `UserDefaults`.
+
+### Automatically synchronize data with iCloud
+
+You can create an automatically synchronizing `Defaults.Key` by setting the `iCloud` parameter to true.
+
+```swift
+extension Defaults.Keys {
+	static let isUnicornMode = Key<Bool>("isUnicornMode", default: true, iCloud: true)
+}
+
+Task {
+	await Defaults.iCloud.sync() // Using sync to make sure all synchronization tasks are done.
+	print(NSUbiquitousKeyValueStore.default.bool(forKey: Defaults.Keys.isUnicornMode.name))
+	//=> true
+}
+```
+
+Also you can synchronize `Defaults.Key` manually, but make sure you select correct `source`. 
+
+```swift
+extension Defaults.Keys {
+	static let isUnicornMode = Key<Bool>("isUnicornMode", default: true)
+}
+
+Defaults.iCloud.syncKeys(.isUnicornMode, source: .local) // This will synchronize the value of the `isUnicornMode` key from the local source. 
+print(NSUbiquitousKeyValueStore.default.bool(forKey: Defaults.Keys.isUnicornMode.name))
+//=> true
+```
+
 
 ## API
 


### PR DESCRIPTION
## Summary

This PR fixes: #75

Create a `Defaults.iCloud` class which facilitates the synchronization of keys between the local `UserDefaults` and `NSUbiquitousKeyValueStore`. 
This class utilizes a `TaskQueue` to execute synchronization tasks sequentially, ensuring proper order and coordination.
Internally, `Defaults.iCloud` contains an `AtomicSet` that indicates the synchronization status of each key. This set prevents observation triggers when synchronization is being executed.

And I also create a new protocol `Defaults.KeyValueStore` which contains essential properties for synchronizing a key value store. It can be useful when mocking a test or even support another key value data source.


## Thanks

Please feel free to critique, and thanks for your code review 😄 .
Any feedback on the PR is welcomed and appreciated 🙇 !

