### PR TITLE
Fixes infinite recursion when casting `AnySerializable` to wrong type

### DIFF
--- a/Sources/Defaults/Utilities.swift
+++ b/Sources/Defaults/Utilities.swift
@@ -194,7 +194,7 @@ extension Defaults.Serializable {
 			return anyObject
 		}
 
-		guard let nextType = T.Serializable.self as? any Defaults.Serializable.Type else {
+        guard let nextType = T.Serializable.self as? any Defaults.Serializable.Type, nextType != T.self else {
 			// This is a special case for the types which do not conform to `Defaults.Serializable` (for example, `Any`).
 			return T.bridge.deserialize(anyObject as? T.Serializable) as? T
 		}

--- a/Sources/Defaults/Utilities.swift
+++ b/Sources/Defaults/Utilities.swift
@@ -194,7 +194,7 @@ extension Defaults.Serializable {
 			return anyObject
 		}
 
-        guard let nextType = T.Serializable.self as? any Defaults.Serializable.Type, nextType != T.self else {
+		guard let nextType = T.Serializable.self as? any Defaults.Serializable.Type, nextType != T.self else {
 			// This is a special case for the types which do not conform to `Defaults.Serializable` (for example, `Any`).
 			return T.bridge.deserialize(anyObject as? T.Serializable) as? T
 		}

--- a/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
+++ b/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
@@ -466,4 +466,10 @@ final class DefaultsAnySerializableTests: XCTestCase {
 
 		waitForExpectations(timeout: 10)
 	}
+
+    func testWrongCast() {
+        let value = Defaults.AnySerializable(false)
+        XCTAssertEqual(value.get(Bool.self), false)
+        XCTAssertNil(value.get(String.self))
+    }
 }

--- a/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
+++ b/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
@@ -466,7 +466,7 @@ final class DefaultsAnySerializableTests: XCTestCase {
 
 		waitForExpectations(timeout: 10)
 	}
-
+	
 	func testWrongCast() {
 		let value = Defaults.AnySerializable(false)
 		XCTAssertEqual(value.get(Bool.self), false)

--- a/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
+++ b/Tests/DefaultsTests/DefaultsAnySeriliazableTests.swift
@@ -467,9 +467,9 @@ final class DefaultsAnySerializableTests: XCTestCase {
 		waitForExpectations(timeout: 10)
 	}
 
-    func testWrongCast() {
-        let value = Defaults.AnySerializable(false)
-        XCTAssertEqual(value.get(Bool.self), false)
-        XCTAssertNil(value.get(String.self))
-    }
+	func testWrongCast() {
+		let value = Defaults.AnySerializable(false)
+		XCTAssertEqual(value.get(Bool.self), false)
+		XCTAssertNil(value.get(String.self))
+	}
 }


### PR DESCRIPTION
If a values associated type `Serializable` , equals the values type, `toValue` would infinitely call itself.

The test `testWrongCast` reproduces this and I fixed it by comparing the `nextType` with the current type.