### PR TITLE
Fix support for non-string keys in dictionaries

### DIFF
--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -132,7 +132,7 @@ extension Array: Defaults.Serializable where Element: Defaults.Serializable {
 }
 
 extension Dictionary: Defaults.Serializable where Key: LosslessStringConvertible & Hashable, Value: Defaults.Serializable {
-	public static var isNativelySupportedType: Bool { Value.isNativelySupportedType }
+	public static var isNativelySupportedType: Bool { (Key.self is String.Type) && Value.isNativelySupportedType }
 	public static var bridge: Defaults.DictionaryBridge<Key, Value> { Defaults.DictionaryBridge() }
 }
 

--- a/Tests/DefaultsTests/DefaultsDictionaryTests.swift
+++ b/Tests/DefaultsTests/DefaultsDictionaryTests.swift
@@ -57,6 +57,15 @@ final class DefaultsDictionaryTests: XCTestCase {
 		XCTAssertEqual(Defaults[key]["0"], [newName, fixtureArray[1]])
 	}
 
+	func testIntKey() {
+		let fixture = [1: "x"]
+		let key = Defaults.Key<[Int: String]>("independentDictionaryIntKey", default: fixture)
+		XCTAssertEqual(Defaults[key][1], fixture[1])
+		let newValue = "John"
+		Defaults[key][1] = newValue
+		XCTAssertEqual(Defaults[key][1], newValue)
+	}
+
 	func testType() {
 		XCTAssertEqual(Defaults[.dictionary]["0"], fixtureDictionary["0"])
 		let newName = "Chen"


### PR DESCRIPTION
`UserDefaults#set(dictionary, forKey: ...)` only supports a string-keyed dictionary. If you try to set `[1: true]`, it currently throws an Objective-C exception.