### PR TITLE
Fix for freezes in MenuBarExtra and NavigationStack

### DIFF
--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -36,6 +36,8 @@ public enum Defaults {
 }
 
 public typealias _Defaults = Defaults
+
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 public typealias _Default = Default
 
 extension Defaults {

--- a/Sources/Defaults/SwiftUI.swift
+++ b/Sources/Defaults/SwiftUI.swift
@@ -108,7 +108,7 @@ public struct Default<Value: Defaults.Serializable>: DynamicProperty {
 	*/
 	public init(_ key: Defaults.Key<Value>) {
 		self.key = key
-        self._observable = .init(wrappedValue: .init(key))
+		self._observable = .init(wrappedValue: .init(key))
 	}
 
 	public var wrappedValue: Value {
@@ -131,7 +131,7 @@ public struct Default<Value: Defaults.Serializable>: DynamicProperty {
 	public var publisher: Publisher { Defaults.publisher(key) }
 
 	public mutating func update() {
-        observable.key = key
+		observable.key = key
 		_observable.update()
 	}
 


### PR DESCRIPTION
This PR changes the internal code of the `@Default` property wrapper, so it uses StateObject instead of ObservableObject. This solves issue #144 

As StateObject is not supported in SwiftUI 1.0, an `@available` has been added. This could be a breaking change for projects with the minimum target set to iOS 13.0 etc.

Instead of creating a new model when the key changes (which is what happened previously), the key will now be changed in the model itself. An extra check is done to make sure that the observers are not restarted too often.