### PR TITLE
add PrivacyInfo.xcprivacy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
 	],
 	targets: [
 		.target(
-			name: "Defaults"
+			name: "Defaults",
+			resources: [.copy("PrivacyInfo.xcprivacy")]
 		),
 		.testTarget(
 			name: "DefaultsTests",

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C56D.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Apple has declared that it will reject applications and SDKs without a privacy manifest starting in the spring of 2024.  
SDKs that use UserDefaults need a privacy manifest, so PrivacyInfo.xcprivacy has been added.  

The following document was used as a reference for setting up the file.  
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files