### PR TITLE
Add collected data types for Privacy Manifest

### DIFF
--- a/Sources/Defaults/PrivacyInfo.xcprivacy
+++ b/Sources/Defaults/PrivacyInfo.xcprivacy
@@ -3,20 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeOther</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
close #164 

I added `NSPrivacyCollectedDataType` with reference to the following page and verified that the privacy manifest is generated correctly.  
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests

<img width="1018" alt="304344905-85e5b929-5dd4-4c6b-8479-6b17db515465" src="https://github.com/sindresorhus/Defaults/assets/19305363/1c3ee613-6114-46b1-afd0-df71fea98f40">
