### PR TITLE
Fix existential-any for Swift6

### DIFF
--- a/Sources/Defaults/Defaults+iCloud.swift
+++ b/Sources/Defaults/Defaults+iCloud.swift
@@ -209,7 +209,7 @@ Manages `Defaults.Keys` between the locale and remote storage.
 Depending on the storage, `Defaults.Keys` will be represented in different forms due to storage limitations of the remote storage. The remote storage imposes a limitation of 1024 keys. Therefore, we combine the recorded timestamp and data into a single key. Unlike remote storage, local storage does not have this limitation. Therefore, we can create a separate key (with `defaultsSyncKey` suffix) for the timestamp record.
 */
 final class iCloudSynchronizer {
-	init(remoteStorage: DefaultsKeyValueStore) {
+	init(remoteStorage: any DefaultsKeyValueStore) {
 		self.remoteStorage = remoteStorage
 		registerNotifications()
 		remoteStorage.synchronize()
@@ -231,7 +231,7 @@ final class iCloudSynchronizer {
 	/**
 	A remote key value storage.
 	*/
-	private let remoteStorage: DefaultsKeyValueStore
+	private let remoteStorage: any DefaultsKeyValueStore
 
 	/**
 	A FIFO queue used to serialize synchronization on keys.

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -126,7 +126,7 @@ extension Defaults {
 
 			super.init(name: name, suite: suite)
 
-			if (defaultValue as? _DefaultsOptionalProtocol)?._defaults_isNil == true {
+			if (defaultValue as? (any _DefaultsOptionalProtocol))?._defaults_isNil == true {
 				return
 			}
 

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -85,7 +85,7 @@ extension Defaults {
 	}
 
 	private static var preventPropagationThreadDictionaryKey: String {
-		"\(type(of: Observation.self))_threadUpdatingValuesFlag"
+		"\(type(of: (any Observation).self))_threadUpdatingValuesFlag"
 	}
 
 	/**
@@ -460,7 +460,7 @@ extension Defaults {
 		_ key: Key<Value>,
 		options: ObservationOptions = [.initial],
 		handler: @escaping (KeyChange<Value>) -> Void
-	) -> Observation {
+	) -> some Observation {
 		let observation = UserDefaultsKeyObservation(object: key.suite, key: key.name) { change in
 			handler(
 				KeyChange(change: change, defaultValue: key.defaultValue)
@@ -490,7 +490,7 @@ extension Defaults {
 		keys: _AnyKey...,
 		options: ObservationOptions = [.initial],
 		handler: @escaping () -> Void
-	) -> Observation {
+	) -> some Observation {
 		let pairs = keys.map {
 			(suite: $0.suite, key: $0.name)
 		}

--- a/Sources/Defaults/UserDefaults.swift
+++ b/Sources/Defaults/UserDefaults.swift
@@ -10,7 +10,7 @@ extension UserDefaults {
 	}
 
 	 func _set<Value: Defaults.Serializable>(_ key: String, to value: Value) {
-		 if (value as? (any _DefaultsOptionalProtocol))?._defaults_isNil == true {
+		if (value as? (any _DefaultsOptionalProtocol))?._defaults_isNil == true {
 			removeObject(forKey: key)
 			return
 		}

--- a/Sources/Defaults/UserDefaults.swift
+++ b/Sources/Defaults/UserDefaults.swift
@@ -10,7 +10,7 @@ extension UserDefaults {
 	}
 
 	 func _set<Value: Defaults.Serializable>(_ key: String, to value: Value) {
-		if (value as? _DefaultsOptionalProtocol)?._defaults_isNil == true {
+		 if (value as? (any _DefaultsOptionalProtocol))?._defaults_isNil == true {
 			removeObject(forKey: key)
 			return
 		}


### PR DESCRIPTION
Added `any` to each protocols to resolve `existential-any` build errors on Swift 6.  
https://github.com/swiftlang/swift-evolution/blob/main/proposals/0335-existential-any.md