### PR TITLE
Fix build error for SE-0401

### DIFF
--- a/Sources/Defaults/SwiftUI.swift
+++ b/Sources/Defaults/SwiftUI.swift
@@ -75,6 +75,7 @@ Access stored values from SwiftUI.
 
 This is similar to `@AppStorage` but it accepts a ``Defaults/Key`` and many more types.
 */
+@MainActor
 @propertyWrapper
 public struct Default<Value: Defaults.Serializable>: DynamicProperty {
 	public typealias Publisher = AnyPublisher<Defaults.KeyChange<Value>, Never>

--- a/Tests/DefaultsTests/DefaultsSwiftUITests.swift
+++ b/Tests/DefaultsTests/DefaultsSwiftUITests.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
 	}
 }
 
+@MainActor
 final class DefaultsSwiftUITests: XCTestCase {
 	override func setUp() {
 		super.setUp()


### PR DESCRIPTION
In `SE-0401` , which will take effect in Swift 6, types with `@StateObject` will no longer be MainActor.  
`@StateObject` must be referenced from MainActor or a build error will occur, so `@MainActor` is added.  
https://github.com/swiftlang/swift-evolution/blob/main/proposals/0401-remove-property-wrapper-isolation.md