### PR TITLE
Fix build error for SE-0409

### DIFF
--- a/Sources/Defaults/Defaults+Bridge.swift
+++ b/Sources/Defaults/Defaults+Bridge.swift
@@ -1,4 +1,5 @@
-import SwiftUI
+public import Foundation
+public import SwiftUI
 #if os(macOS)
 import AppKit
 #else

--- a/Sources/Defaults/Defaults+Extensions.swift
+++ b/Sources/Defaults/Defaults+Extensions.swift
@@ -1,4 +1,5 @@
-import SwiftUI
+public import Foundation
+public import SwiftUI
 #if os(macOS)
 import AppKit
 #else

--- a/Sources/Defaults/Defaults+Protocol.swift
+++ b/Sources/Defaults/Defaults+Protocol.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 extension Defaults {
 	/**

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -1,5 +1,5 @@
 // MIT License © Sindre Sorhus
-import Foundation
+public import Foundation
 
 public enum Defaults {
 	/**

--- a/Sources/Defaults/Observation+Combine.swift
+++ b/Sources/Defaults/Observation+Combine.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Combine
+public import Combine
 
 extension Defaults {
 	/**

--- a/Sources/Defaults/Observation.swift
+++ b/Sources/Defaults/Observation.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 public protocol _DefaultsObservation: AnyObject {
 	func invalidate()

--- a/Sources/Defaults/Reset.swift
+++ b/Sources/Defaults/Reset.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 extension Defaults {
 	/**

--- a/Sources/Defaults/SwiftUI.swift
+++ b/Sources/Defaults/SwiftUI.swift
@@ -1,5 +1,5 @@
-import SwiftUI
-import Combine
+public import SwiftUI
+public import Combine
 
 extension Defaults {
 	@MainActor

--- a/Sources/Defaults/UserDefaults.swift
+++ b/Sources/Defaults/UserDefaults.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 extension UserDefaults {
 	func _get<Value: Defaults.Serializable>(_ key: String) -> Value? {

--- a/Sources/Defaults/Utilities.swift
+++ b/Sources/Defaults/Utilities.swift
@@ -1,6 +1,6 @@
-import Foundation
+public import Foundation
 import Combine
-import os
+public import os
 #if DEBUG && canImport(OSLog)
 import OSLog
 #endif


### PR DESCRIPTION
`SE-0409` , introduced in Swift 6, changes `import` from implicit `public import` to `internal import`.  
The `internal import` does not allow imports to be `public` and will result in build errors, so `public` has been added.  
https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md