### PR TITLE
Disable syncing from local if its default after `iCloud.add`

### DIFF
--- a/Sources/Defaults/Defaults+iCloud.swift
+++ b/Sources/Defaults/Defaults+iCloud.swift
@@ -82,7 +82,8 @@ extension Defaults {
 		/**
 		Add the keys to be automatically synced.
 		*/
-		// TODO: support array of Defaults.Key after swift 6 Pack iteration
+		// TODO: Support array of Defaults.Key after Swift 6 pack iteration is supported.
+		// https://github.com/sindresorhus/Defaults/pull/185#discussion_r1704464183
 		public static func add<each Value: Defaults.Serializable>(_ keys: repeat Defaults.Key<each Value>) {
 			repeat synchronizer.add(each keys)
 		}

--- a/Sources/Defaults/Defaults+iCloud.swift
+++ b/Sources/Defaults/Defaults+iCloud.swift
@@ -82,6 +82,7 @@ extension Defaults {
 		/**
 		Add the keys to be automatically synced.
 		*/
+		// TODO: support array of Defaults.Key after swift 6 Pack iteration
 		public static func add<each Value: Defaults.Serializable>(_ keys: repeat Defaults.Key<each Value>) {
 			repeat synchronizer.add(each keys)
 		}
@@ -267,12 +268,15 @@ final class iCloudSynchronizer {
 		guard isInserted else {
 			return
 		}
+
 		localKeysMonitor.add(key: key)
+
 		// If the local value is the default value, only sync from remote, since all devices should already have the default value.
-		if key.isDefaultValue() {
+		if key._isDefaultValue {
 			guard case .remote = latestDataSource(forKey: key) else {
 				return
 			}
+
 			syncWithoutWaiting([key], .remote)
 		} else {
 			syncWithoutWaiting([key])

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -191,7 +191,7 @@ extension Defaults.Key {
 	/**
 	Check whether the stored value is the default value.
 
-	- Note: This is only for internal use cause wouldn't work for non-equatable values.
+	- Note: This is only for internal use because it would not work for non-equatable values.
 	*/
 	var _isDefaultValue: Bool {
 		let defaultValue = defaultValue

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -190,8 +190,10 @@ extension Defaults.Key {
 
 	/**
 	Check whether the stored value is the default value.
+
+	- Note: This is only for internal use cause wouldn't work for non-equatable values.
 	*/
-	public func isDefaultValue() -> Bool {
+	var _isDefaultValue: Bool {
 		let defaultValue = defaultValue
 		let value = suite[self]
 		guard
@@ -203,6 +205,13 @@ extension Defaults.Key {
 
 		return defaultValue.isEqual(value)
 	}
+}
+
+extension Defaults.Key where Value: Equatable {
+	/**
+	Check whether the stored value is the default value.
+	*/
+	public var isDefaultValue: Bool { self._isDefaultValue }
 }
 
 extension Defaults {

--- a/Sources/Defaults/Defaults.swift
+++ b/Sources/Defaults/Defaults.swift
@@ -187,6 +187,22 @@ extension Defaults.Key {
 	) where Value == T? {
 		self.init(name, default: nil, suite: suite, iCloud: iCloud)
 	}
+
+	/**
+	Check whether the stored value is the default value.
+	*/
+	public func isDefaultValue() -> Bool {
+		let defaultValue = defaultValue
+		let value = suite[self]
+		guard
+			let defaultValue = defaultValue as? any Equatable,
+			let value = value as? any Equatable
+		else {
+			return false
+		}
+
+		return defaultValue.isEqual(value)
+	}
 }
 
 extension Defaults {

--- a/Sources/Defaults/Utilities.swift
+++ b/Sources/Defaults/Utilities.swift
@@ -165,6 +165,16 @@ extension Collection {
 	}
 }
 
+extension Equatable {
+	func isEqual(_ rhs: any Equatable) -> Bool {
+		if let rhs = rhs as? Self, rhs == self {
+			return true
+		}
+
+		return false
+	}
+}
+
 extension Defaults {
 	@usableFromInline
 	static func isValidKeyPath(name: String) -> Bool {

--- a/Sources/Defaults/Utilities.swift
+++ b/Sources/Defaults/Utilities.swift
@@ -167,11 +167,14 @@ extension Collection {
 
 extension Equatable {
 	func isEqual(_ rhs: any Equatable) -> Bool {
-		if let rhs = rhs as? Self, rhs == self {
-			return true
+		guard
+			let rhs = rhs as? Self,
+			rhs == self
+		else {
+			return false
 		}
 
-		return false
+		return true
 	}
 }
 

--- a/Tests/DefaultsTests/Defaults+iCloudTests.swift
+++ b/Tests/DefaultsTests/Defaults+iCloudTests.swift
@@ -88,14 +88,12 @@ final class DefaultsICloudTests: XCTestCase {
 	}
 
 	func testICloudInitialize() async {
-		print(Defaults.iCloud.keys)
 		let name = Defaults.Key<String>("testICloudInitialize_name", default: "0", iCloud: true)
 		let quality = Defaults.Key<Double>("testICloudInitialize_quality", default: 0.0, iCloud: true)
 
-		print(Defaults.iCloud.keys)
 		await Defaults.iCloud.waitForSyncCompletion()
-		XCTAssertEqual(mockStorage.data(forKey: name.name), "0")
-		XCTAssertEqual(mockStorage.data(forKey: quality.name), 0.0)
+		XCTAssertNil(mockStorage.data(forKey: name.name))
+		XCTAssertNil(mockStorage.data(forKey: quality.name))
 		let name_expected = ["1", "2", "3", "4", "5", "6", "7"]
 		let quality_expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
 
@@ -251,8 +249,9 @@ final class DefaultsICloudTests: XCTestCase {
 
 	func testAddFromDetached() async {
 		let name = Defaults.Key<String>("testInitAddFromDetached_name", default: "0")
+		let quantity = Defaults.Key<Bool>("testInitAddFromDetached_quantity", default: false)
 		let task = Task.detached {
-			Defaults.iCloud.add(name)
+			Defaults.iCloud.add(name, quantity)
 			Defaults.iCloud.syncWithoutWaiting()
 			await Defaults.iCloud.waitForSyncCompletion()
 		}
@@ -268,7 +267,7 @@ final class DefaultsICloudTests: XCTestCase {
 			let name = Defaults.Key<String>("testICloudInitializeFromDetached_name", default: "0", iCloud: true)
 
 			await Defaults.iCloud.waitForSyncCompletion()
-			XCTAssertEqual(mockStorage.data(forKey: name.name), "0")
+			XCTAssertNil(mockStorage.data(forKey: name.name))
 		}
 		await task.value
 	}

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -179,9 +179,9 @@ final class DefaultsTests: XCTestCase {
 
 	func testIsDefaultValue() {
 		let key = Defaults.Key<Bool>("isDefaultValue", default: false)
-		XCTAssert(key.isDefaultValue())
+		XCTAssert(key.isDefaultValue)
 		Defaults[key].toggle()
-		XCTAssert(!key.isDefaultValue())
+		XCTAssert(!key.isDefaultValue)
 	}
 
 	func testObserveKeyCombine() {

--- a/Tests/DefaultsTests/DefaultsTests.swift
+++ b/Tests/DefaultsTests/DefaultsTests.swift
@@ -177,6 +177,13 @@ final class DefaultsTests: XCTestCase {
 		Defaults.removeAll(suite: customSuite)
 	}
 
+	func testIsDefaultValue() {
+		let key = Defaults.Key<Bool>("isDefaultValue", default: false)
+		XCTAssert(key.isDefaultValue())
+		Defaults[key].toggle()
+		XCTAssert(!key.isDefaultValue())
+	}
+
 	func testObserveKeyCombine() {
 		let key = Defaults.Key<Bool>("observeKey", default: false)
 		let expect = expectation(description: "Observation closure being called")


### PR DESCRIPTION
## Description

This PR fixes #172.

By default, `Defaults` will create a sync task that automatically detects the data source using timestamps. However, this might cause an issue if the device is newly installed, as it might accidentally push the default value to iCloud. It's also unnecessary to publish the default value to iCloud upon initialization, since all devices should already have that value.

## Implementation

Added a new function `isDefaultValue` for `Defaults.Key<Value>`. 
To detect if the locally stored value is a default value, I had to change `Defaults.iCloud.add` to use a generic packed parameter. 

## Question

This change introduces a new issue: we cannot support `Defaults.iCloud.add` with an array of `Defaults.Key<Value>` due to the lack of variadic parameter support. Is there any way to resolve this?
