### PR TITLE
Add `constant` method to support SwiftUI previews and tests

### DIFF
--- a/Sources/Defaults/SwiftUI.swift
+++ b/Sources/Defaults/SwiftUI.swift
@@ -274,3 +274,35 @@ private struct ViewStorage<Value>: DynamicProperty {
 		self._valueBox = .init(wrappedValue: ValueBox(value()))
 	}
 }
+
+extension Default {
+	/**
+	A `Default` instance with a constant value.
+	
+	This is particularly useful for setting default values in SwiftUI previews.
+
+	- Parameter value: The constant value to be used as the default.
+	- Returns: A `Default<Value>` instance initialized with the specified constant value.
+
+	```swift
+	extension Defaults.Keys {
+		static let hasUnicorn = Key<Bool>("hasUnicorn", default: false)
+	}
+
+	struct ContentView: View {
+		@Default(.hasUnicorn) var hasUnicorn
+
+		var body: some View {
+			Toggle("Toggle", isOn: $hasUnicorn)
+		}
+	}
+
+	#Preview {
+		ContentView(hasUnicorn: .constant(true))
+	}
+    ```
+	*/
+	public static func constant(_ value: Value) -> Default<Value> {
+		Default<Value>(.init("__constant_\(value)", default: value))
+	}
+}

--- a/Tests/DefaultsTests/DefaultsSwiftUITests.swift
+++ b/Tests/DefaultsTests/DefaultsSwiftUITests.swift
@@ -59,4 +59,15 @@ final class DefaultsSwiftUITests: XCTestCase {
 		XCTAssertNotEqual(XColor(view.color), XColor(Color.black))
 		XCTAssertEqual(XColor(view.color), XColor(Color(.sRGB, red: 100, green: 100, blue: 100, opacity: 1)))
 	}
+
+	func testConstantValue() {
+		// Given: A `Defaults` key `hasUnicorn` with `false` as the default value.
+		XCTAssertFalse(Defaults[.hasUnicorn])
+
+		// When: A `ContentView` is created with a constant value set to `true`.
+		let view = ContentView(hasUnicorn: .constant(true))
+
+		// Then: The state value of the view should be `true`.
+		XCTAssertTrue(view.hasUnicorn)
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -201,6 +201,10 @@ struct ContentView: View {
 		}
 	}
 }
+
+#Preview {
+	ContentView(hasUnicorn: .constant(true))
+}
 ```
 
 Note that it's `@Default`, not `@Defaults`.


### PR DESCRIPTION
### Description
This PR introduces a constant method to the Default extension, allowing developers to easily create default values that can be used in SwiftUI previews and unit tests. This addition simplifies the process of providing mock data and ensures that default values are consistent across different components of the app.

### Key Changes
- Added a constant(_:) method to the Default extension.
- The method creates a Default<Value> instance with a specified constant value, particularly useful for SwiftUI previews and testing scenarios.
- Updated documentation to include a usage example within a SwiftUI preview.

### Usage Example
Here’s how you can use the new constant method in a SwiftUI preview:
```swift
extension Defaults.Keys {
    static let hasUnicorn = Key<Bool>("hasUnicorn", default: false)
}

struct ContentView: View {
    @Default(.hasUnicorn) var hasUnicorn

    var body: some View {
        Toggle("Toggle", isOn: $hasUnicorn)
    }
}

#Preview {
	ContentView(hasUnicorn: .constant(true))
}
```
In this example, the constant method is used to set up a mock for `hasUnicorn` key, making it easy to visualize the view with a predefined value during development.

### Testing
- Unit tests have been added to verify that the constant(_:) method correctly initializes Default<Value> instances with the specified constant values.
- Manual testing has been performed to ensure that the method works seamlessly in SwiftUI previews.

### Additional Notes
- This new functionality is backward-compatible and doesn’t affect any existing code.
- It is particularly helpful for scenarios where you need to isolate and test UI components with predictable data.