### PR TITLE
Implement @ObservableDefaults macro

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "1ba60ebd54db82e47e39bc8db179589187c069067eb0a8cd6ec19d2301c5abc4",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.10
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
 	name: "Defaults",
@@ -16,17 +17,47 @@ let package = Package(
 			targets: [
 				"Defaults"
 			]
+		),
+		.library(
+			name: "DefaultsMacros",
+			targets: [
+				"DefaultsMacros"
+			]
 		)
+	],
+	dependencies: [
+		.package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0")
 	],
 	targets: [
 		.target(
 			name: "Defaults",
 			resources: [.copy("PrivacyInfo.xcprivacy")]
 		),
+		.macro(
+			name: "DefaultsMacrosDeclarations",
+			dependencies: [
+				"Defaults",
+				.product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+				.product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+			]
+		),
+		.target(
+			name: "DefaultsMacros",
+			dependencies: ["Defaults", "DefaultsMacrosDeclarations"]
+		),
 		.testTarget(
 			name: "DefaultsTests",
 			dependencies: [
 				"Defaults"
+			]
+		),
+		.testTarget(
+			name: "DefaultsMacrosTests",
+			dependencies: [
+				"DefaultsMacros",
+				"DefaultsMacrosDeclarations",
+				.product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+				.product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
 			]
 		)
 	]

--- a/Sources/DefaultsMacros/ObservableDefaults.swift
+++ b/Sources/DefaultsMacros/ObservableDefaults.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+import Defaults
+
+@attached(accessor, names: named(get), named(set))
+public macro ObservableDefaults<Value>(_ key: Defaults.Key<Value>) =
+	#externalMacro(
+		module: "DefaultsMacrosDeclarations",
+		type: "ObservableDefaultsMacro"
+	)

--- a/Sources/DefaultsMacrosDeclarations/ObservableDefaultsMacro.swift
+++ b/Sources/DefaultsMacrosDeclarations/ObservableDefaultsMacro.swift
@@ -1,0 +1,117 @@
+import SwiftCompilerPlugin
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct ObservableDefaultsMacro: AccessorMacro {
+	public static func expansion(
+		of node: AttributeSyntax,
+		providingAccessorsOf declaration: some DeclSyntaxProtocol,
+		in context: some MacroExpansionContext
+	) throws -> [AccessorDeclSyntax] {
+		// Must be attached to a property declaration.
+		guard let variableDeclaration = declaration.as(VariableDeclSyntax.self) else {
+			throw ObservableDefaultsError.notAttachedToProperty
+		}
+
+		// Must be attached to a variable property (i.e. `var` and not `let`).
+		guard variableDeclaration.bindingSpecifier.tokenKind == .keyword(.var) else {
+			throw ObservableDefaultsError.notAttachedToVariable
+		}
+
+		// Must be attached to a single property.
+		guard variableDeclaration.bindings.count == 1, let binding = variableDeclaration.bindings.first else {
+			throw ObservableDefaultsError.notAttachedToSingleProperty
+		}
+
+		// Must not provide an initializer for the property (i.e. not assign a value).
+		guard binding.initializer == nil else {
+			throw ObservableDefaultsError.attachedToPropertyWithInitializer
+		}
+
+		// Must not be attached to property with existing accessor block.
+		guard binding.accessorBlock == nil else {
+			throw ObservableDefaultsError.attachedToPropertyWithAccessorBlock
+		}
+
+		// Must use Identifier Pattern.
+		// See https://swiftinit.org/docs/swift-syntax/swiftsyntax/identifierpatternsyntax
+		guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier else {
+			throw ObservableDefaultsError.attachedToPropertyWithoutIdentifierProperty
+		}
+
+		// Must receive arguments
+		guard let arguments = node.arguments else {
+			throw ObservableDefaultsError.calledWithoutArguments
+		}
+
+		// Must be called with Labeled Expression.
+		// See https://swiftinit.org/docs/swift-syntax/swiftsyntax/labeledexprlistsyntax
+		guard let expressionList = arguments.as(LabeledExprListSyntax.self) else {
+			throw ObservableDefaultsError.calledWithoutLabeledExpression
+		}
+
+		// Must only receive one argument.
+		guard expressionList.count == 1, let expression = expressionList.first?.expression else {
+			throw ObservableDefaultsError.calledWithMultipleArguments
+		}
+
+		return [
+			#"""
+			get {
+				access(keyPath: \.\#(pattern))
+				return Defaults[\#(expression)]
+			}
+			"""#,
+			#"""
+			set {
+				withMutation(keyPath: \.\#(pattern)) {
+					Defaults[\#(expression)] = newValue
+				}
+			}
+			"""#
+		]
+	}
+}
+
+enum ObservableDefaultsError: Error {
+	case notAttachedToProperty
+	case notAttachedToVariable
+	case notAttachedToSingleProperty
+	case attachedToPropertyWithInitializer
+	case attachedToPropertyWithAccessorBlock
+	case attachedToPropertyWithoutIdentifierProperty
+	case calledWithoutArguments
+	case calledWithoutLabeledExpression
+	case calledWithMultipleArguments
+	case calledWithoutFunctionSyntax
+	case calledWithoutKeyArgument
+	case calledWithUnsupportedExpression
+}
+
+extension ObservableDefaultsError: CustomStringConvertible {
+	var description: String {
+		switch self {
+		case .notAttachedToProperty:
+			"@ObservableDefaults must be attached to a property."
+		case .notAttachedToVariable:
+			"@ObservableDefaults must be attached to a `var` property."
+		case .notAttachedToSingleProperty:
+			"@ObservableDefaults can only be attached to a single property."
+		case .attachedToPropertyWithInitializer:
+			"@ObservableDefaults must not be attached with a property with a value assigned. To create set default value, provide it in the `Defaults.Key` definition."
+		case .attachedToPropertyWithAccessorBlock:
+			"@ObservableDefaults must not be attached to a property with accessor block."
+		case .attachedToPropertyWithoutIdentifierProperty:
+			"@ObservableDefaults could not identify the attached property."
+		case .calledWithoutArguments,
+			 .calledWithoutLabeledExpression,
+			 .calledWithMultipleArguments,
+			 .calledWithoutFunctionSyntax,
+			 .calledWithoutKeyArgument,
+			 .calledWithUnsupportedExpression:
+			"@ObservableDefaults must be called with (1) argument of type `Defaults.Key`"
+		}
+	}
+}

--- a/Sources/DefaultsMacrosDeclarations/ObservableDefaultsPlugin.swift
+++ b/Sources/DefaultsMacrosDeclarations/ObservableDefaultsPlugin.swift
@@ -1,0 +1,9 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct DefaultsMacrosPlugin: CompilerPlugin {
+	let providingMacros: [Macro.Type] = [
+		ObservableDefaultsMacro.self
+	]
+}

--- a/Tests/DefaultsMacrosTests/DefaultsMacrosTests.swift
+++ b/Tests/DefaultsMacrosTests/DefaultsMacrosTests.swift
@@ -1,0 +1,127 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+// Macro implementations build for the host, so the corresponding module is not available when cross-compiling.
+// Cross-compiled tests may still make use of the macro itself in end-to-end tests.
+#if canImport(DefaultsMacrosDeclarations)
+@testable import DefaultsMacros
+@testable import DefaultsMacrosDeclarations
+
+let testMacros: [String: Macro.Type] = [
+	"ObservableDefaults": ObservableDefaultsMacro.self,
+]
+#endif
+
+final class ObservableDefaultsMacrosTests: XCTestCase {
+	func testObservableDefaultsWithKeyPath() throws {
+		#if canImport(DefaultsMacrosDeclarations)
+		assertMacroExpansion(
+			#"""
+			@Observable
+			class ObservableClass {
+				@ObservableDefaults(\.name)
+				@ObservationIgnored
+				var name: String
+			}
+			"""#,
+			expandedSource:
+			#"""
+			@Observable
+			class ObservableClass {
+				@ObservationIgnored
+				var name: String {
+					get {
+						access(keyPath: \.name)
+						return Defaults[\.name]
+					}
+					set {
+						withMutation(keyPath: \.name) {
+							Defaults[\.name] = newValue
+						}
+					}
+				}
+			}
+			"""#,
+			macros: testMacros,
+			indentationWidth: .tabs(1)
+		)
+		#else
+		throw XCTSkip("Macros are only supported when running tests for the host platform")
+		#endif
+	}
+
+	func testObservableDefaultsWithFunctionCall() throws {
+		#if canImport(DefaultsMacrosDeclarations)
+		assertMacroExpansion(
+			#"""
+			@Observable
+			class ObservableClass {
+				@ObservableDefaults(getName())
+				@ObservationIgnored
+				var name: String
+			}
+			"""#,
+			expandedSource:
+			#"""
+			@Observable
+			class ObservableClass {
+				@ObservationIgnored
+				var name: String {
+					get {
+						access(keyPath: \.name)
+						return Defaults[getName()]
+					}
+					set {
+						withMutation(keyPath: \.name) {
+							Defaults[getName()] = newValue
+						}
+					}
+				}
+			}
+			"""#,
+			macros: testMacros,
+			indentationWidth: .tabs(1)
+		)
+		#else
+		throw XCTSkip("Macros are only supported when running tests for the host platform")
+		#endif
+	}
+
+	func testObservableDefaultsWithProperty() throws {
+		#if canImport(DefaultsMacrosDeclarations)
+		assertMacroExpansion(
+			#"""
+			@Observable
+			class ObservableClass {
+				@ObservableDefaults(propertyName)
+				@ObservationIgnored
+				var name: String
+			}
+			"""#,
+			expandedSource:
+			#"""
+			@Observable
+			class ObservableClass {
+				@ObservationIgnored
+				var name: String {
+					get {
+						access(keyPath: \.name)
+						return Defaults[propertyName]
+					}
+					set {
+						withMutation(keyPath: \.name) {
+							Defaults[propertyName] = newValue
+						}
+					}
+				}
+			}
+			"""#,
+			macros: testMacros,
+			indentationWidth: .tabs(1)
+		)
+		#else
+		throw XCTSkip("Macros are only supported when running tests for the host platform")
+		#endif
+	}
+}


### PR DESCRIPTION
Hi there! Thought I'd pitch in and contribute to this great package. This addresses #142 by creating a new macro that can be used inside `@Observable` classes.

The macro is implemented in a new `DefaultsMacros` module. The decision to do so is based on the introduction of a new dependency on `swift-syntax`, and to keep the main module dependency-free (specially since the syntax package adds quite a bit to build times). Please, let me know if you'd rather move it to the main module.

Settings the PR as draft for early review, but there are at least a couple things I want to do to get it ready. Also, I haven't put much thought into the naming; advice on this is appreciated.

## TODO

- [ ] Figure out if `@ObservationIgnored` can be added automatically as part of the macro.
- [ ] Add docstring to the macro declaration.
- [ ] Add info on how to use the macro to the README.