### PR TITLE
Fix @Default triggering an extra redraw on appear

### DIFF
--- a/Sources/Defaults/SwiftUI.swift
+++ b/Sources/Defaults/SwiftUI.swift
@@ -39,7 +39,7 @@ extension Defaults {
 
 				// The `@MainActor` is important as the `.send()` method doesn't inherit the `@MainActor` from the class.
 				task = .detached(priority: .userInitiated) { @MainActor [weak self, key] in
-					for await _ in Defaults.updates(key) {
+					for await _ in Defaults.updates(key, initial: false) {
 						guard let self else {
 							return
 						}


### PR DESCRIPTION
I noticed that any view using a `@Default` property wrapper, was getting their body re-evaluated twice when appearing. 

This is what the logs look like when showing a simple view that uses `@Default` when adding a `Self._printChanges()`.
```
DefaultView: @self, @identity, @8 changed.
DefaultView: @8 changed.
```

The first line is totally normal, but the second line indicates that the value of `@Default` changed (no idea why SwiftUI is referring to it as `@8`).

I noticed that the `Observable` the property wrapper is using, will always send a `objectWillChange` after being initialized, even though it is already initialized with the correct value. Adding a `initial` parameter fixes this and will still update the property wrapper (and view) when the value actually changes.

After the change, only the first line gets logged.

Here is also the test project I used for this: [Host.zip](https://github.com/user-attachments/files/18246871/Host.zip)
