### PR TITLE
Fix Swift@6.1 type inference compile error

### DIFF
--- a/Sources/Defaults/Utilities.swift
+++ b/Sources/Defaults/Utilities.swift
@@ -373,6 +373,7 @@ final class TaskQueue {
 				queueContinuation?.yield {
 					continuation.resume()
 				}
+				return
 			}
 		}
 	}


### PR DESCRIPTION
## WHY

- Failed to compile on `Swift@6.1 (Xcode 16.1 Beta 1)`

> Conflicting arguments to generic parameter 'R' ('Void' vs. 'AsyncStream<TaskQueue.AsyncTask>.Continuation.YieldResult?')

```
swift-driver version: 1.120.2 Apple Swift version 6.1 (swiftlang-6.1.0.106.4 clang-1700.0.9.2)
Target: arm64-apple-macosx15.0
```

## WHAT

- Avoid to inference TaskQueue.AsyncTask type in `lock.with<T>`. This should be inferenced as `Void`.