### PR TITLE
Use Xcode 16.2 stack in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - run: sudo xcode-select -switch /Applications/Xcode_16.app
+      - run: sudo xcode-select -switch /Applications/Xcode_16.2.app
       - run: swift test
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## WHY

- `Xcode_16.app` is removed by recent stack updates.

## WHAT

- Use latest stable Xcode version, 16.2.
- https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md