### PR TITLE
Abort the synchronization task if no data source exists

### DIFF
--- a/Tests/DefaultsTests/Defaults+iCloudTests.swift
+++ b/Tests/DefaultsTests/Defaults+iCloudTests.swift
@@ -281,8 +281,8 @@ final class DefaultsICloudTests {
 
 	@Test
 	func testAddFromDetached() async {
-		let name = Defaults.Key<String?>("testInitAddFromDetached_name", suite: suite)
-		let quantity = Defaults.Key<Bool?>("testInitAddFromDetached_quantity", suite: suite)
+		let name = Defaults.Key<String?>("testInitAddFromDetached_name", suite: suite) // swiftlint:disable:this discouraged_optional_boolean
+		let quantity = Defaults.Key<Bool?>("testInitAddFromDetached_quantity", suite: suite) // swiftlint:disable:this discouraged_optional_boolean
 		await Task.detached {
 			Defaults.iCloud.add(name, quantity)
 			Defaults[name] = "0"


### PR DESCRIPTION
## Description

This PR fixes #206.

Previously, when a user newly installed the app, we would create some synchronization tasks.  
Since the app was newly installed, both the remote and local data sources did not have a timestamp record, so we would sync the local data source to the remote one, which might override values in iCloud.

With this PR, we will abort the synchronization task if both the remote and local data sources do not have a timestamp record.  
This prevents unintended data overrides and allows developers to wait for iCloud synchronization instead (call `synchronize` on app launch and wait for `didChangeExternallyNotification`).

## Implementation

- Make `Defaults.iCloud.latestDataSource` return an optional. If it returns `nil`, we should abort the synchronization task.
- Add a new `SyncStatus.abort` in the logger to indicate that the key synchronization has been aborted.

## Discussion

Should we provide a function that ensures iCloud is synced?

ex. 

```swift
func waitForRemoteSynced() async -> Notification? {
	await NotificationCenter.default.notifications(named: NSUbiquitousKeyValueStore.didChangeExternallyNotification).first
}
```

