### PR TITLE
Update the dependency “swift-syntax” to version 602+ to avoid conflicts

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "99c6a158de8e73f99d0eadf6f19484d15f690d625b21f16adb21029f35e01415",
+  "originHash" : "cf5cf4c5f9c4867ff6ef039acc4dfaa43710d7da97102796b391fe5022910b23",
   "pins" : [
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		)
 	],
 	dependencies: [
-		.package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.0")
+		.package(url: "https://github.com/swiftlang/swift-syntax", from: "602.0.0")
 	],
 	targets: [
 		.target(


### PR DESCRIPTION
Update the dependency “swift-syntax” to version 602+ to avoid conflicts with the latest version of the "swiftlint" library.