### PR TITLE
Enable users to specify their preferred Swift syntax options to facilitate a flexible transition

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		)
 	],
 	dependencies: [
-		.package(url: "https://github.com/swiftlang/swift-syntax", from: "603.0.0")
+		.package(url: "https://github.com/swiftlang/swift-syntax", "602.0.0"..<"605.0.0")
 	],
 	targets: [
 		.target(


### PR DESCRIPTION
## WHAT

- Support swift-syntax upper bound from 602 to 605 to support 602.x, 603.x and 604.x prereleases.

## HOW

This approach is used in libraries such as [pointfree’s](https://github.com/search?q=org%3Apointfreeco+https%3A%2F%2Fgithub.com%2Fswiftlang%2Fswift-syntax+603.0.0&type=code); since fixing the Swift syntax version would require updating all dependent libraries at once, this option allows for multiple versions provided there are no breaking changes.

I understand how far back we should support, but wouldn’t it be possible to handle updates more flexibly by supporting the latest version and the previous one?